### PR TITLE
Flushing out the transaction set basics

### DIFF
--- a/src/main/java/com/walmartlabs/x12/AbstractX12TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/AbstractX12TransactionSet.java
@@ -1,0 +1,60 @@
+package com.walmartlabs.x12;
+
+/**
+ * 
+ * the {@link AbstractX12TransactionSet} is not required when creating a 
+ * custom {@link X12TransactionSet}. It is provided as a convenience to handle 
+ * common ST/SE elements. 
+ *
+ */
+public abstract class AbstractX12TransactionSet implements X12TransactionSet {
+    /*
+     * ST
+     */
+    // ST01
+    private String transactionSetIdentifierCode;
+    // ST02
+    private String headerControlNumber;
+
+    /*
+     * SE
+     */
+    // SE01
+    private Integer expectedNumberOfSegments;
+    // SE02
+    private String trailerControlNumber;
+    
+    
+    public String getTransactionSetIdentifierCode() {
+        return transactionSetIdentifierCode;
+    }
+
+    public void setTransactionSetIdentifierCode(String transactionSetIdentifierCode) {
+        this.transactionSetIdentifierCode = transactionSetIdentifierCode;
+    }
+
+    public String getHeaderControlNumber() {
+        return headerControlNumber;
+    }
+
+    public void setHeaderControlNumber(String headerControlNumber) {
+        this.headerControlNumber = headerControlNumber;
+    }
+
+    public Integer getExpectedNumberOfSegments() {
+        return expectedNumberOfSegments;
+    }
+
+    public void setExpectedNumberOfSegments(Integer expectedNumberOfSegments) {
+        this.expectedNumberOfSegments = expectedNumberOfSegments;
+    }
+
+    public String getTrailerControlNumber() {
+        return trailerControlNumber;
+    }
+
+    public void setTrailerControlNumber(String trailerControlNumber) {
+        this.trailerControlNumber = trailerControlNumber;
+    }
+
+}

--- a/src/main/java/com/walmartlabs/x12/X12TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/X12TransactionSet.java
@@ -15,6 +15,55 @@ limitations under the License.
  */
 package com.walmartlabs.x12;
 
+/**
+ * 
+ * Implementations should store the common ST/SE elements 
+ * as well as the attributes specific to the particular 
+ * transaction type. 
+ *
+ */
 public interface X12TransactionSet {
+    
+    /**
+     * The ST01 segment element contains the functional group code, which 
+     * identifies the X12 transaction type 
+     * 
+     * common X12 transaction types associated with retail are 856 (ASN), 
+     * 850 (PO), and 812 (invoice). 
+     * 
+     * @return the ST01 segment value 
+     */
+    String getTransactionSetIdentifierCode();
+    
+    void setTransactionSetIdentifierCode(String transactionSetIdentifierCode);
 
+    /**
+     * The ST02 segment element contains the control number. This should match
+     * the control number on the corresponding transaction trailer segment.
+     * 
+     * @return the ST02 segment value 
+     */
+    String getHeaderControlNumber() ;
+    
+    void setHeaderControlNumber(String headerControlNumber);
+
+    /**
+     * The SE01 segment element contains the number of segments that 
+     * are in this transaction.
+     * 
+     * @return the SE01 segment value 
+     */
+    Integer getExpectedNumberOfSegments();
+    
+    void setExpectedNumberOfSegments(Integer expectedNumberOfSegments);
+
+    /**
+     * The SE02 segment element contains the control number. This should match
+     * the control number on the corresponding transaction header segment.
+     * 
+     * @return the SE02 segment value 
+     */
+    String getTrailerControlNumber();
+    
+    void setTrailerControlNumber(String trailerControlNumber);
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/AsnTransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/AsnTransactionSet.java
@@ -15,9 +15,10 @@ limitations under the License.
  */
 package com.walmartlabs.x12.asn856;
 
-import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.AbstractX12TransactionSet;
 
-public class AsnTransactionSet implements X12TransactionSet {
+public class AsnTransactionSet extends AbstractX12TransactionSet {
+
     private String sampleAsnOnly;
 
     public String getSampleAsnOnly() {

--- a/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894TransactionSet.java
@@ -15,7 +15,7 @@ limitations under the License.
  */
 package com.walmartlabs.x12.dex.dx894;
 
-import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.AbstractX12TransactionSet;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -25,22 +25,8 @@ import java.util.List;
  * The 894 Base Record Transaction Set is essentially an invoice.
  * Note: Debits and credits cannot mix on the same invoice
  */
-public class Dex894TransactionSet implements X12TransactionSet {
-    /*
-     * ST
-     */
-    // ST01
-    private String transactionSetIdentifierCode;
-    // ST02
-    private String headerControlNumber;
+public class Dex894TransactionSet extends AbstractX12TransactionSet {
 
-    /*
-     * SE
-     */
-    // SE01
-    private Integer expectedNumberOfSegments;
-    // SE02
-    private String trailerControlNumber;
     // used for validation routines
     // to cmp against expected segments
     private Integer actualNumberOfSegments;
@@ -107,30 +93,6 @@ public class Dex894TransactionSet implements X12TransactionSet {
             items = new ArrayList<>();
         }
         items.add(dexItem);
-    }
-
-    public String getTransactionSetIdentifierCode() {
-        return transactionSetIdentifierCode;
-    }
-
-    public void setTransactionSetIdentifierCode(String transactionSetIdentifierCode) {
-        this.transactionSetIdentifierCode = transactionSetIdentifierCode;
-    }
-
-    public String getHeaderControlNumber() {
-        return headerControlNumber;
-    }
-
-    public void setHeaderControlNumber(String headerControlNumber) {
-        this.headerControlNumber = headerControlNumber;
-    }
-
-    public String getTrailerControlNumber() {
-        return trailerControlNumber;
-    }
-
-    public void setTrailerControlNumber(String trailerControlNumber) {
-        this.trailerControlNumber = trailerControlNumber;
     }
 
     public String getSupplierNumber() {
@@ -235,14 +197,6 @@ public class Dex894TransactionSet implements X12TransactionSet {
 
     public void setSignatureName(String signatureName) {
         this.signatureName = signatureName;
-    }
-
-    public Integer getExpectedNumberOfSegments() {
-        return expectedNumberOfSegments;
-    }
-
-    public void setExpectedNumberOfSegments(Integer expectedNumberOfSegments) {
-        this.expectedNumberOfSegments = expectedNumberOfSegments;
     }
 
     public Integer getActualNumberOfSegments() {

--- a/src/main/java/com/walmartlabs/x12/po850/PurchaseOrderTransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/po850/PurchaseOrderTransactionSet.java
@@ -15,7 +15,7 @@ limitations under the License.
  */
 package com.walmartlabs.x12.po850;
 
-import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.AbstractX12TransactionSet;
 
 /**
  * 
@@ -23,6 +23,7 @@ import com.walmartlabs.x12.X12TransactionSet;
  * a parsed PO 850 transaction set
  *
  */
-public class PurchaseOrderTransactionSet implements X12TransactionSet {
+public class PurchaseOrderTransactionSet extends AbstractX12TransactionSet {
+
 
 }

--- a/src/test/java/com/walmartlabs/x12/standard/StandardX12ParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/StandardX12ParserTest.java
@@ -241,9 +241,11 @@ public class StandardX12ParserTest {
         assertEquals(2, group1TxList.size());
         X12TransactionSet tx1 = group1TxList.get(0);
         assertTrue(tx1 instanceof TypeAaaTransactionSet);
-        assertEquals("1", ((TypeAaaTransactionSet)tx1).getValue());
+        assertEquals("AAA", tx1.getTransactionSetIdentifierCode());
+        assertEquals("1", ((TypeAaaTransactionSet)tx1).getAaaOnlyValue());
         X12TransactionSet tx2 = group1TxList.get(1);
         assertTrue(tx2 instanceof TypeBbbTransactionSet);
+        assertEquals("BBB", tx2.getTransactionSetIdentifierCode());
         assertEquals("2", ((TypeBbbTransactionSet)tx2).getValue());
         
         // group 2
@@ -263,7 +265,8 @@ public class StandardX12ParserTest {
         assertEquals(1, group2TxList.size());
         X12TransactionSet tx3 = group2TxList.get(0);
         assertTrue(tx3 instanceof TypeAaaTransactionSet);
-        assertEquals("3", ((TypeAaaTransactionSet)tx3).getValue());
+        assertEquals("AAA", tx3.getTransactionSetIdentifierCode());
+        assertEquals("3", ((TypeAaaTransactionSet)tx3).getAaaOnlyValue());
     }
     
     private StandardX12Parser createParserWithRegistration() {

--- a/src/test/java/sample/aaa/AaaTransactionSetParser.java
+++ b/src/test/java/sample/aaa/AaaTransactionSetParser.java
@@ -21,7 +21,8 @@ public class AaaTransactionSetParser extends AbstractTransactionSetParserChainab
         assertEquals("SE", txLines.get(2).getSegmentIdentifier());
         
         TypeAaaTransactionSet tx = new TypeAaaTransactionSet();
-        tx.setValue(txLines.get(1).getSegmentElement(1));
+        tx.setTransactionSetIdentifierCode(txLines.get(0).getSegmentElement(1));
+        tx.setAaaOnlyValue(txLines.get(1).getSegmentElement(1));
         return tx;
     }
 

--- a/src/test/java/sample/aaa/TypeAaaTransactionSet.java
+++ b/src/test/java/sample/aaa/TypeAaaTransactionSet.java
@@ -1,15 +1,15 @@
 package sample.aaa;
 
-import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.AbstractX12TransactionSet;
 
-public class TypeAaaTransactionSet implements X12TransactionSet {
-    private String value;
-
-    public String getValue() {
-        return value;
+public class TypeAaaTransactionSet extends AbstractX12TransactionSet {
+    private String anAaaOnlyValue;
+    
+    public String getAaaOnlyValue() {
+        return anAaaOnlyValue;
     }
 
-    public void setValue(String value) {
-        this.value = value;
+    public void setAaaOnlyValue(String value) {
+        this.anAaaOnlyValue = value;
     }
 }

--- a/src/test/java/sample/bbb/BbbTransactionSetParser.java
+++ b/src/test/java/sample/bbb/BbbTransactionSetParser.java
@@ -21,6 +21,7 @@ public class BbbTransactionSetParser extends AbstractTransactionSetParserChainab
         assertEquals("SE", txLines.get(2).getSegmentIdentifier());
         
         TypeBbbTransactionSet tx = new TypeBbbTransactionSet();
+        tx.setTransactionSetIdentifierCode(txLines.get(0).getSegmentElement(1));
         tx.setValue(txLines.get(1).getSegmentElement(1));
         return tx;
     }

--- a/src/test/java/sample/bbb/TypeBbbTransactionSet.java
+++ b/src/test/java/sample/bbb/TypeBbbTransactionSet.java
@@ -1,8 +1,9 @@
 package sample.bbb;
 
-import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.AbstractX12TransactionSet;
 
-public class TypeBbbTransactionSet implements X12TransactionSet {
+public class TypeBbbTransactionSet extends AbstractX12TransactionSet {
+    
     private String value;
 
     public String getValue() {
@@ -12,4 +13,5 @@ public class TypeBbbTransactionSet implements X12TransactionSet {
     public void setValue(String value) {
         this.value = value;
     }
+
 }

--- a/src/test/java/sample/yyz/TypeYyzTransactionSet.java
+++ b/src/test/java/sample/yyz/TypeYyzTransactionSet.java
@@ -1,10 +1,62 @@
 package sample.yyz;
 
+import com.walmartlabs.x12.AbstractX12TransactionSet;
 import com.walmartlabs.x12.X12TransactionSet;
 
+/**
+ * 
+ * the {@link AbstractX12TransactionSet} is not required when creating a 
+ * custom {@link X12TransactionSet}. It is provided as a convenience to handle 
+ * common ST/SE elements. 
+ *
+ */
 public class TypeYyzTransactionSet implements X12TransactionSet {
+    private String transactionSetIdentifierCode;
+    private String headerControlNumber;
+    private String trailerControlNumber;
+    private Integer numSegments;
     private String value;
 
+    @Override
+    public String getTransactionSetIdentifierCode() {
+        return this.transactionSetIdentifierCode;
+    }
+
+    @Override
+    public void setTransactionSetIdentifierCode(String transactionSetIdentifierCode) {
+        this.transactionSetIdentifierCode = transactionSetIdentifierCode;
+    }
+    
+    @Override
+    public String getHeaderControlNumber() {
+        return headerControlNumber;
+    }
+    
+    @Override
+    public void setHeaderControlNumber(String headerControlNumber) {
+        this.headerControlNumber = headerControlNumber;
+    }
+
+    @Override
+    public String getTrailerControlNumber() {
+        return trailerControlNumber;
+    }
+
+    @Override
+    public void setTrailerControlNumber(String trailerControlNumber) {
+        this.trailerControlNumber = trailerControlNumber;
+    }
+    
+    @Override
+    public Integer getExpectedNumberOfSegments() {
+        return numSegments;
+    }
+
+    @Override
+    public void setExpectedNumberOfSegments(Integer expectedNumberOfSegments) {
+        this.numSegments = expectedNumberOfSegments;
+    }
+    
     public String getValue() {
         return value;
     }
@@ -12,5 +64,6 @@ public class TypeYyzTransactionSet implements X12TransactionSet {
     public void setValue(String value) {
         this.value = value;
     }
+
     
 }

--- a/src/test/java/sample/yyz/YyzTransactionSetParser.java
+++ b/src/test/java/sample/yyz/YyzTransactionSetParser.java
@@ -7,12 +7,6 @@ import com.walmartlabs.x12.standard.X12Group;
 
 import java.util.List;
 
-/**
- * 
- * TODO: what should a "normal" TransactionSetParser if it is handed a 
- * transaction set it can't handle? 
- *
- */
 public class YyzTransactionSetParser implements TransactionSetParser {
 
     @Override
@@ -22,6 +16,7 @@ public class YyzTransactionSetParser implements TransactionSetParser {
             String type = txLines.get(0).getSegmentElement(1);
             if ("YYZ".equals(type)) {
                 tx = new TypeYyzTransactionSet();
+                tx.setTransactionSetIdentifierCode(type);
                 X12Segment nextLine = txLines.get(1);
                 if (nextLine != null) {
                     tx.setValue(nextLine.getSegmentElement(1));


### PR DESCRIPTION
Approach for common ST/SE attributes 
Backward compatible w/ DEX implementation

the ST/SE is common across all X12 so this provides access to ST elements w/o having to cast

Foundation for #43 