### PR TITLE
Refactors for Gozer utils and types shared across document/transactions

### DIFF
--- a/src/main/java/com/walmartlabs/x12/SegmentIterator.java
+++ b/src/main/java/com/walmartlabs/x12/SegmentIterator.java
@@ -1,6 +1,4 @@
-package com.walmartlabs.x12.util;
-
-import com.walmartlabs.x12.X12Segment;
+package com.walmartlabs.x12;
 
 import java.util.List;
 import java.util.ListIterator;

--- a/src/main/java/com/walmartlabs/x12/X12Document.java
+++ b/src/main/java/com/walmartlabs/x12/X12Document.java
@@ -16,7 +16,7 @@ limitations under the License.
 package com.walmartlabs.x12;
 
 /**
- *
+ * standard interface for all X12 documents
  */
 public interface X12Document {
 

--- a/src/main/java/com/walmartlabs/x12/X12Parser.java
+++ b/src/main/java/com/walmartlabs/x12/X12Parser.java
@@ -16,7 +16,6 @@ limitations under the License.
 package com.walmartlabs.x12;
 
 import com.walmartlabs.x12.exceptions.X12ParserException;
-import com.walmartlabs.x12.util.X12ParsingUtil;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;

--- a/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
+++ b/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
@@ -1,7 +1,5 @@
-package com.walmartlabs.x12.util;
+package com.walmartlabs.x12;
 
-import com.walmartlabs.x12.X12Segment;
-import com.walmartlabs.x12.X12TransactionSet;
 import com.walmartlabs.x12.dex.dx894.DefaultDex894Parser;
 import com.walmartlabs.x12.exceptions.X12ErrorDetail;
 import com.walmartlabs.x12.exceptions.X12ParserException;
@@ -51,8 +49,8 @@ public final class X12ParsingUtil {
                 // need at least 2 lines to have valid envelope
                 X12Segment headerSegment = segmentList.get(0);
                 X12Segment trailerSegment = segmentList.get(lastSegmentIndex);
-                if (headerIdentifier.equals(headerSegment.getSegmentIdentifier())
-                    && trailerIdentifier.equals(trailerSegment.getSegmentIdentifier())) {
+                if (headerIdentifier.equals(headerSegment.getIdentifier())
+                    && trailerIdentifier.equals(trailerSegment.getIdentifier())) {
                     isValidEnvelope = true;
                 }
             }
@@ -79,7 +77,7 @@ public final class X12ParsingUtil {
                 
                 X12Segment firstSegment = segmentList.get(0);
                 if (firstSegment != null) {
-                    String segmentType = firstSegment.getSegmentElement(1);
+                    String segmentType = firstSegment.getElement(1);
                     if (transactionType.equals(segmentType)) {
                         isTransactionType = true;
                     }
@@ -135,7 +133,7 @@ public final class X12ParsingUtil {
             if (isHierarchalLoopStart(firstSegment)) {
                 loops = processLoops(segmentList);
             } else {
-                String actualSegment = (firstSegment != null ? firstSegment.getSegmentIdentifier() : "");
+                String actualSegment = (firstSegment != null ? firstSegment.getIdentifier() : "");
                 throw handleUnexpectedSegment("HL", actualSegment);
             }
         }
@@ -205,18 +203,18 @@ public final class X12ParsingUtil {
      * @return true if HL otherwise false
      */
     private static boolean isHierarchalLoopStart(X12Segment segment) {
-        return segment != null && "HL".equals(segment.getSegmentIdentifier());
+        return segment != null && "HL".equals(segment.getIdentifier());
     }
     
     private static X12Loop buildHierarchalLoop(X12Segment x12Segment) {
         // starting new loop
-        String loopId = x12Segment.getSegmentElement(1);
-        String parentLoopId = x12Segment.getSegmentElement(2);
+        String loopId = x12Segment.getElement(1);
+        String parentLoopId = x12Segment.getElement(2);
 
         X12Loop loop = new X12Loop();
         loop.setHierarchicalId(loopId);
         loop.setParentHierarchicalId(parentLoopId);
-        loop.setCode(x12Segment.getSegmentElement(3));
+        loop.setCode(x12Segment.getElement(3));
         
         return loop;
     }

--- a/src/main/java/com/walmartlabs/x12/X12Segment.java
+++ b/src/main/java/com/walmartlabs/x12/X12Segment.java
@@ -21,6 +21,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ *  Each line in an X12 document is called a segment
+ *  Each segment contains one or more elements
+ *  The first element identifies the type of segment
+ *  
+ *  This class will parse a segment into the individual elements
+ */
 public class X12Segment {
     
     private String segmentValue;
@@ -58,7 +65,7 @@ public class X12Segment {
      * extracts the first data element in a segment which is the segment identifier
      * otherwise return an empty String
      */
-    public String getSegmentIdentifier() {
+    public String getIdentifier() {
         if (segmentElements != null && !segmentElements.isEmpty()) {
             return segmentElements.get(0);
         } else {
@@ -69,7 +76,7 @@ public class X12Segment {
     /**
      * retrieve the element at a particular index in the segment
      */
-    public String getSegmentElement(int index) {
+    public String getElement(int index) {
         if (segmentElements.size() > index) {
             String value = segmentElements.get(index);
             return StringUtils.isEmpty(value) ? null : value;

--- a/src/main/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParser.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParser.java
@@ -15,13 +15,13 @@ limitations under the License.
  */
 package com.walmartlabs.x12.asn856;
 
+import com.walmartlabs.x12.X12ParsingUtil;
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.X12TransactionSet;
 import com.walmartlabs.x12.standard.AbstractTransactionSetParserChainable;
 import com.walmartlabs.x12.standard.X12Group;
 import com.walmartlabs.x12.standard.X12Loop;
 import com.walmartlabs.x12.util.ConversionUtil;
-import com.walmartlabs.x12.util.X12ParsingUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +92,7 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
         // CTT (optional)
         //
         currentSegment = transactionSegments.get(segementAfterHierarchicalLoops);
-        if (ASN_TRANSACTION_TOTALS.equals(currentSegment.getSegmentIdentifier())) {
+        if (ASN_TRANSACTION_TOTALS.equals(currentSegment.getIdentifier())) {
             this.parseTransactionTotals(currentSegment, asnTx);
             currentSegment = transactionSegments.get(segmentCount - 1);
         }
@@ -112,7 +112,7 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
         int secondToLastSegmentIndex = segmentCount - 2;
         X12Segment segment = transactionSegments.get(secondToLastSegmentIndex);
         // 2nd to last line is CTT (optional) otherwise it is part of HL
-        if (ASN_TRANSACTION_TOTALS.equals(segment.getSegmentIdentifier())) {
+        if (ASN_TRANSACTION_TOTALS.equals(segment.getIdentifier())) {
             // CTT segment
             return secondToLastSegmentIndex;
         } else {
@@ -127,12 +127,12 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
      * @param asnTx
      */
     private void parseTransactionSetHeader(X12Segment segment, AsnTransactionSet asnTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (X12TransactionSet.TRANSACTION_SET_HEADER.equals(segmentIdentifier)) {
-            asnTx.setTransactionSetIdentifierCode(segment.getSegmentElement(1));
-            asnTx.setHeaderControlNumber(segment.getSegmentElement(2));
+            asnTx.setTransactionSetIdentifierCode(segment.getElement(1));
+            asnTx.setHeaderControlNumber(segment.getElement(2));
         } else {
             throw X12ParsingUtil.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_HEADER, segmentIdentifier);
         }
@@ -144,12 +144,12 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
      * @param asnTx
      */
     private void parseTransactionSetTrailer(X12Segment segment, AsnTransactionSet asnTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (X12TransactionSet.TRANSACTION_SET_TRAILER.equals(segmentIdentifier)) {
-            asnTx.setExpectedNumberOfSegments(ConversionUtil.convertStringToInteger(segment.getSegmentElement(1)));
-            asnTx.setTrailerControlNumber(segment.getSegmentElement(2));
+            asnTx.setExpectedNumberOfSegments(ConversionUtil.convertStringToInteger(segment.getElement(1)));
+            asnTx.setTrailerControlNumber(segment.getElement(2));
         } else {
             throw X12ParsingUtil.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, segmentIdentifier);
         }
@@ -161,15 +161,15 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
      * @param asnTx
      */
     private void parseBeginningSegment(X12Segment segment, AsnTransactionSet asnTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
         
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (ASN_TRANSACTION_HEADER.equals(segmentIdentifier)) {
-            asnTx.setPurposeCode(segment.getSegmentElement(1));
-            asnTx.setShipmentIdentification(segment.getSegmentElement(2));
-            asnTx.setShipmentDate(segment.getSegmentElement(3));
-            asnTx.setShipmentTime(segment.getSegmentElement(4));
-            asnTx.setHierarchicalStructureCode(segment.getSegmentElement(5));
+            asnTx.setPurposeCode(segment.getElement(1));
+            asnTx.setShipmentIdentification(segment.getElement(2));
+            asnTx.setShipmentDate(segment.getElement(3));
+            asnTx.setShipmentTime(segment.getElement(4));
+            asnTx.setHierarchicalStructureCode(segment.getElement(5));
         } else {
             throw X12ParsingUtil.handleUnexpectedSegment(ASN_TRANSACTION_HEADER, segmentIdentifier);
         }
@@ -181,11 +181,11 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
      * @param asnTx
      */
     private void parseTransactionTotals(X12Segment segment, AsnTransactionSet asnTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (ASN_TRANSACTION_TOTALS.equals(segmentIdentifier)) {
-            asnTx.setTransactionLineItems(ConversionUtil.convertStringToInteger(segment.getSegmentElement(1)));
+            asnTx.setTransactionLineItems(ConversionUtil.convertStringToInteger(segment.getElement(1)));
         } else {
             throw X12ParsingUtil.handleUnexpectedSegment(ASN_TRANSACTION_TOTALS, segmentIdentifier);
         }

--- a/src/main/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParser.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParser.java
@@ -103,6 +103,10 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
         this.parseTransactionSetTrailer(currentSegment, asnTx);
     }
 
+    protected Shipment doLoopParsing(List<X12Loop> loops, AsnTransactionSet asnTx) {
+        return null;
+    }
+    
     private int findSegmentAfterHierarchicalLoops(List<X12Segment> transactionSegments) {
         int segmentCount = transactionSegments.size();
         int secondToLastSegmentIndex = segmentCount - 2;

--- a/src/main/java/com/walmartlabs/x12/dex/dx894/DefaultDex894Parser.java
+++ b/src/main/java/com/walmartlabs/x12/dex/dx894/DefaultDex894Parser.java
@@ -16,10 +16,13 @@ limitations under the License.
 package com.walmartlabs.x12.dex.dx894;
 
 import com.walmartlabs.x12.X12Parser;
+import com.walmartlabs.x12.X12ParsingUtil;
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.exceptions.X12ParserException;
+import com.walmartlabs.x12.types.InvoiceType;
+import com.walmartlabs.x12.types.ProductQualifier;
+import com.walmartlabs.x12.types.UnitMeasure;
 import com.walmartlabs.x12.util.ConversionUtil;
-import com.walmartlabs.x12.util.X12ParsingUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
@@ -140,7 +143,7 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
     protected int parseDexTransaction(final int startingIdx, final List<X12Segment> dexSegments, final Dex894TransactionSet dexTx) {
         LOGGER.debug("parseDexTransaction:" + startingIdx);
         X12Segment segment = dexSegments.get(startingIdx);
-        String segmentId = segment.getSegmentIdentifier();
+        String segmentId = segment.getIdentifier();
 
         int segmentIdx = startingIdx;
         if (!TRANSACTION_SET_HEADER_ID.equals(segmentId)) {
@@ -160,19 +163,19 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
             do {
                 segmentIdx = this.parseDexTransactionLoop(segmentIdx, dexSegments, dexTx);
                 segment = dexSegments.get(segmentIdx);
-                segmentId = segment.getSegmentIdentifier();
+                segmentId = segment.getIdentifier();
             } while (TRANSACTION_SET_HEADER_ID.equals(segmentId));
 
             // next set of lines after the transaction loop can vary
             segment = dexSegments.get(segmentIdx);
-            segmentId = segment.getSegmentIdentifier();
+            segmentId = segment.getIdentifier();
 
             // G84 line (conditional)
             if (G84_ID.equals(segmentId)) {
                 this.parseG84(segment, dexTx);
                 // update next segment & segment id
                 segment = dexSegments.get(++segmentIdx);
-                segmentId = segment.getSegmentIdentifier();
+                segmentId = segment.getIdentifier();
             }
 
             // G86 line (optional)
@@ -221,7 +224,7 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
     protected int parseDexTransactionLoop(final int startingIdx, final List<X12Segment> dexSegments, final Dex894TransactionSet dexTx) {
         LOGGER.debug("parseDexTransactionLoop:" + startingIdx);
         X12Segment segment = dexSegments.get(startingIdx);
-        String segmentId = segment.getSegmentIdentifier();
+        String segmentId = segment.getIdentifier();
 
         int segmentIdx = startingIdx;
         if (!LOOP_HEADER_ID.equals(segmentId)) {
@@ -236,7 +239,7 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
             do {
                 // get the segment
                 segment = dexSegments.get(segmentIdx);
-                segmentId = segment.getSegmentIdentifier();
+                segmentId = segment.getIdentifier();
 
                 if (G83_ID.equals(segmentId)) {
                     segmentIdx = this.parseDexItem(segmentIdx, dexSegments, dexTx);
@@ -276,14 +279,14 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
 
         // check next segments
         segment = dexSegments.get(++segmentIdx);
-        String segmentId = segment.getSegmentIdentifier();
+        String segmentId = segment.getIdentifier();
 
         // G22 pricing (optional)
         if (G22_ID.equals(segmentId)) {
             this.parseG22(segment, dexItem);
             // update next segment & segment id
             segment = dexSegments.get(++segmentIdx);
-            segmentId = segment.getSegmentIdentifier();
+            segmentId = segment.getIdentifier();
         }
 
         // G72 allowance (optional)
@@ -291,7 +294,7 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
             this.parseG72(segment, dexItem);
             // update next segment & segment id
             segment = dexSegments.get(++segmentIdx);
-            segmentId = segment.getSegmentIdentifier();
+            segmentId = segment.getIdentifier();
         }
 
         dexTx.addItem(dexItem);
@@ -307,17 +310,17 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseApplicationHeader(X12Segment headerSegment, Dex894 dex) {
-        LOGGER.debug(headerSegment.getSegmentIdentifier());
+        LOGGER.debug(headerSegment.getIdentifier());
 
-        String segmentIdentifer = headerSegment.getSegmentIdentifier();
+        String segmentIdentifer = headerSegment.getIdentifier();
         if (DEX_HEADER_ID.equals(segmentIdentifer)) {
-            dex.setSenderCommId(headerSegment.getSegmentElement(1));
-            dex.setFunctionalId(headerSegment.getSegmentElement(2));
-            dex.setVersion(headerSegment.getSegmentElement(3));
+            dex.setSenderCommId(headerSegment.getElement(1));
+            dex.setFunctionalId(headerSegment.getElement(2));
+            dex.setVersion(headerSegment.getElement(3));
             this.parseVersion(dex);
-            dex.setHeaderTransmissionControlNumber(headerSegment.getSegmentElement(4));
-            dex.setReceiverCommId(headerSegment.getSegmentElement(5));
-            dex.setTestIndicator(headerSegment.getSegmentElement(6));
+            dex.setHeaderTransmissionControlNumber(headerSegment.getElement(4));
+            dex.setReceiverCommId(headerSegment.getElement(5));
+            dex.setTestIndicator(headerSegment.getElement(6));
         } else {
             handleUnexpectedSegment(DEX_HEADER_ID, segmentIdentifer);
         }
@@ -337,12 +340,12 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseTransactionSetHeader(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (TRANSACTION_SET_HEADER_ID.equals(segmentIdentifier)) {
-            dexTx.setTransactionSetIdentifierCode(segment.getSegmentElement(1));
-            dexTx.setHeaderControlNumber(segment.getSegmentElement(2));
+            dexTx.setTransactionSetIdentifierCode(segment.getElement(1));
+            dexTx.setHeaderControlNumber(segment.getElement(2));
         } else {
             handleUnexpectedSegment(TRANSACTION_SET_HEADER_ID, segmentIdentifier);
         }
@@ -357,19 +360,19 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseG82(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (G82_ID.equals(segmentIdentifier)) {
-            dexTx.setDebitCreditFlag(InvoiceType.convertDebitCreditFlag(segment.getSegmentElement(1)));
-            dexTx.setSupplierNumber(segment.getSegmentElement(2));
-            dexTx.setReceiverDuns(segment.getSegmentElement(3));
-            dexTx.setReceiverLocation(segment.getSegmentElement(4));
-            dexTx.setSupplierDuns(segment.getSegmentElement(5));
-            dexTx.setSupplierLocation(segment.getSegmentElement(6));
-            dexTx.setTransactionDate(segment.getSegmentElement(7));
-            dexTx.setPurchaseOrderNumber(segment.getSegmentElement(8));
-            dexTx.setPurchaseOrderDate(segment.getSegmentElement(9));
+            dexTx.setDebitCreditFlag(InvoiceType.convertDebitCreditFlag(segment.getElement(1)));
+            dexTx.setSupplierNumber(segment.getElement(2));
+            dexTx.setReceiverDuns(segment.getElement(3));
+            dexTx.setReceiverLocation(segment.getElement(4));
+            dexTx.setSupplierDuns(segment.getElement(5));
+            dexTx.setSupplierLocation(segment.getElement(6));
+            dexTx.setTransactionDate(segment.getElement(7));
+            dexTx.setPurchaseOrderNumber(segment.getElement(8));
+            dexTx.setPurchaseOrderDate(segment.getElement(9));
         } else {
             handleUnexpectedSegment(G82_ID, segmentIdentifier);
         }
@@ -383,9 +386,9 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseLoopHeader(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (!LOOP_HEADER_ID.equals(segmentIdentifier)) {
             handleUnexpectedSegment(LOOP_HEADER_ID, segmentIdentifier);
         }
@@ -402,25 +405,25 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseG83(X12Segment segment, Dex894Item dexItem) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (G83_ID.equals(segmentIdentifier)) {
             // this will do a simple parsing of the G83 elements
             // a separate utility will need to determine the retail selling unit
-            dexItem.setItemSequenceNumber(segment.getSegmentElement(1));
-            dexItem.setQuantity(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(2), 3));
-            dexItem.setUom(UnitMeasure.convertUnitMeasure(segment.getSegmentElement(3)));
-            dexItem.setUpc(segment.getSegmentElement(4));
-            dexItem.setConsumerProductQualifier(ProductQualifier.convertProductQualifier(segment.getSegmentElement(5)));
-            dexItem.setConsumerProductId(segment.getSegmentElement(6));
-            dexItem.setCaseUpc(segment.getSegmentElement(7));
-            dexItem.setItemListCost(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(8), 2));
-            dexItem.setPackCount(ConversionUtil.convertStringToInteger(segment.getSegmentElement(9)));
-            dexItem.setItemDescription(segment.getSegmentElement(10));
-            dexItem.setCaseProductQualifier(ProductQualifier.convertProductQualifier(segment.getSegmentElement(11)));
-            dexItem.setCaseProductId(segment.getSegmentElement(12));
-            dexItem.setInnerPackCount(ConversionUtil.convertStringToInteger(segment.getSegmentElement(13)));
+            dexItem.setItemSequenceNumber(segment.getElement(1));
+            dexItem.setQuantity(ConversionUtil.convertStringToBigDecimal(segment.getElement(2), 3));
+            dexItem.setUom(UnitMeasure.convertUnitMeasure(segment.getElement(3)));
+            dexItem.setUpc(segment.getElement(4));
+            dexItem.setConsumerProductQualifier(ProductQualifier.convertProductQualifier(segment.getElement(5)));
+            dexItem.setConsumerProductId(segment.getElement(6));
+            dexItem.setCaseUpc(segment.getElement(7));
+            dexItem.setItemListCost(ConversionUtil.convertStringToBigDecimal(segment.getElement(8), 2));
+            dexItem.setPackCount(ConversionUtil.convertStringToInteger(segment.getElement(9)));
+            dexItem.setItemDescription(segment.getElement(10));
+            dexItem.setCaseProductQualifier(ProductQualifier.convertProductQualifier(segment.getElement(11)));
+            dexItem.setCaseProductId(segment.getElement(12));
+            dexItem.setInnerPackCount(ConversionUtil.convertStringToInteger(segment.getElement(13)));
         } else {
             handleUnexpectedSegment(G83_ID, segmentIdentifier);
         }
@@ -437,7 +440,7 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseG22(X12Segment segment, Dex894Item dexItem) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
     }
 
     /**
@@ -450,22 +453,22 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseG72(X12Segment segment, Dex894Item dexItem) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (G72_ID.equals(segmentIdentifier)) {
             Dex894Allowance dexAllowance = new Dex894Allowance();
             dexItem.addAllowance(dexAllowance);
-            dexAllowance.setAllowanceCode(segment.getSegmentElement(1));
-            dexAllowance.setMethodOfHandlingCode(segment.getSegmentElement(2));
-            dexAllowance.setAllowanceNumber(segment.getSegmentElement(3));
-            dexAllowance.setExceptionNumber(segment.getSegmentElement(4));
-            dexAllowance.setAllowanceRate(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(5), 4));
-            dexAllowance.setAllowanceQuantity(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(6), 3));
-            dexAllowance.setAllowanceUom(UnitMeasure.convertUnitMeasure(segment.getSegmentElement(7)));
-            dexAllowance.setAllowanceAmount(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(8), 2));
-            dexAllowance.setAllowancePercent(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(9), 3));
-            dexAllowance.setOptionNumber(segment.getSegmentElement(10));
+            dexAllowance.setAllowanceCode(segment.getElement(1));
+            dexAllowance.setMethodOfHandlingCode(segment.getElement(2));
+            dexAllowance.setAllowanceNumber(segment.getElement(3));
+            dexAllowance.setExceptionNumber(segment.getElement(4));
+            dexAllowance.setAllowanceRate(ConversionUtil.convertStringToBigDecimal(segment.getElement(5), 4));
+            dexAllowance.setAllowanceQuantity(ConversionUtil.convertStringToBigDecimal(segment.getElement(6), 3));
+            dexAllowance.setAllowanceUom(UnitMeasure.convertUnitMeasure(segment.getElement(7)));
+            dexAllowance.setAllowanceAmount(ConversionUtil.convertStringToBigDecimal(segment.getElement(8), 2));
+            dexAllowance.setAllowancePercent(ConversionUtil.convertStringToBigDecimal(segment.getElement(9), 3));
+            dexAllowance.setOptionNumber(segment.getElement(10));
         } else {
             handleUnexpectedSegment(G72_ID, segmentIdentifier);
         }
@@ -480,9 +483,9 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseLoopTrailer(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (!LOOP_TRAILER_ID.equals(segmentIdentifier)) {
             handleUnexpectedSegment(LOOP_TRAILER_ID, segmentIdentifier);
         }
@@ -497,13 +500,13 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseG84(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (G84_ID.equals(segmentIdentifier)) {
-            dexTx.setTransactionTotalQuantity(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(1), 3));
-            dexTx.setTransactionTotalAmount(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(2), 2));
-            dexTx.setTransactionTotalDepositAmount(ConversionUtil.convertStringToBigDecimal(segment.getSegmentElement(3), 2));
+            dexTx.setTransactionTotalQuantity(ConversionUtil.convertStringToBigDecimal(segment.getElement(1), 3));
+            dexTx.setTransactionTotalAmount(ConversionUtil.convertStringToBigDecimal(segment.getElement(2), 2));
+            dexTx.setTransactionTotalDepositAmount(ConversionUtil.convertStringToBigDecimal(segment.getElement(3), 2));
         } else {
             handleUnexpectedSegment(G84_ID, segmentIdentifier);
         }
@@ -518,11 +521,11 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseG85(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (G85_ID.equals(segmentIdentifier)) {
-            dexTx.setIntegrityCheckValue(segment.getSegmentElement(1));
+            dexTx.setIntegrityCheckValue(segment.getElement(1));
         } else {
             handleUnexpectedSegment(G85_ID, segmentIdentifier);
         }
@@ -537,12 +540,12 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseG86(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (G86_ID.equals(segmentIdentifier)) {
-            dexTx.setElectronicSignature(segment.getSegmentElement(1));
-            dexTx.setSignatureName(segment.getSegmentElement(2));
+            dexTx.setElectronicSignature(segment.getElement(1));
+            dexTx.setSignatureName(segment.getElement(2));
         } else {
             handleUnexpectedSegment(G86_ID, segmentIdentifier);
         }
@@ -556,12 +559,12 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseTransactionSetTrailer(X12Segment segment, Dex894TransactionSet dexTx) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (TRANSACTION_SET_TRAILER_ID.equals(segmentIdentifier)) {
-            dexTx.setExpectedNumberOfSegments(ConversionUtil.convertStringToInteger(segment.getSegmentElement(1)));
-            dexTx.setTrailerControlNumber(segment.getSegmentElement(2));
+            dexTx.setExpectedNumberOfSegments(ConversionUtil.convertStringToInteger(segment.getElement(1)));
+            dexTx.setTrailerControlNumber(segment.getElement(2));
         } else {
             handleUnexpectedSegment(TRANSACTION_SET_TRAILER_ID, segmentIdentifier);
         }
@@ -575,12 +578,12 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
      * @throws ArrayIndexOutOfBoundsException if a mandatory element is missing
      */
     protected void parseApplicationTrailer(X12Segment trailerSegment, Dex894 dex) {
-        LOGGER.debug(trailerSegment.getSegmentIdentifier());
+        LOGGER.debug(trailerSegment.getIdentifier());
 
-        String segmentIdentifier = trailerSegment.getSegmentIdentifier();
+        String segmentIdentifier = trailerSegment.getIdentifier();
         if (DEX_TRAILER_ID.equals(segmentIdentifier)) {
-            dex.setTrailerTransmissionControlNumber(trailerSegment.getSegmentElement(1));
-            dex.setNumberOfTransactions(ConversionUtil.convertStringToInteger(trailerSegment.getSegmentElement(2)));
+            dex.setTrailerTransmissionControlNumber(trailerSegment.getElement(1));
+            dex.setNumberOfTransactions(ConversionUtil.convertStringToInteger(trailerSegment.getElement(2)));
         } else {
             handleUnexpectedSegment(DEX_TRAILER_ID, segmentIdentifier);
         }

--- a/src/main/java/com/walmartlabs/x12/dex/dx894/DefaultDex894Parser.java
+++ b/src/main/java/com/walmartlabs/x12/dex/dx894/DefaultDex894Parser.java
@@ -364,7 +364,7 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
 
         String segmentIdentifier = segment.getIdentifier();
         if (G82_ID.equals(segmentIdentifier)) {
-            dexTx.setDebitCreditFlag(InvoiceType.convertDebitCreditFlag(segment.getElement(1)));
+            dexTx.setDebitCreditFlag(InvoiceType.convert(segment.getElement(1)));
             dexTx.setSupplierNumber(segment.getElement(2));
             dexTx.setReceiverDuns(segment.getElement(3));
             dexTx.setReceiverLocation(segment.getElement(4));
@@ -413,15 +413,15 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
             // a separate utility will need to determine the retail selling unit
             dexItem.setItemSequenceNumber(segment.getElement(1));
             dexItem.setQuantity(ConversionUtil.convertStringToBigDecimal(segment.getElement(2), 3));
-            dexItem.setUom(UnitMeasure.convertUnitMeasure(segment.getElement(3)));
+            dexItem.setUom(UnitMeasure.convert(segment.getElement(3)));
             dexItem.setUpc(segment.getElement(4));
-            dexItem.setConsumerProductQualifier(ProductQualifier.convertProductQualifier(segment.getElement(5)));
+            dexItem.setConsumerProductQualifier(ProductQualifier.convert(segment.getElement(5)));
             dexItem.setConsumerProductId(segment.getElement(6));
             dexItem.setCaseUpc(segment.getElement(7));
             dexItem.setItemListCost(ConversionUtil.convertStringToBigDecimal(segment.getElement(8), 2));
             dexItem.setPackCount(ConversionUtil.convertStringToInteger(segment.getElement(9)));
             dexItem.setItemDescription(segment.getElement(10));
-            dexItem.setCaseProductQualifier(ProductQualifier.convertProductQualifier(segment.getElement(11)));
+            dexItem.setCaseProductQualifier(ProductQualifier.convert(segment.getElement(11)));
             dexItem.setCaseProductId(segment.getElement(12));
             dexItem.setInnerPackCount(ConversionUtil.convertStringToInteger(segment.getElement(13)));
         } else {
@@ -465,7 +465,7 @@ public class DefaultDex894Parser implements X12Parser<Dex894> {
             dexAllowance.setExceptionNumber(segment.getElement(4));
             dexAllowance.setAllowanceRate(ConversionUtil.convertStringToBigDecimal(segment.getElement(5), 4));
             dexAllowance.setAllowanceQuantity(ConversionUtil.convertStringToBigDecimal(segment.getElement(6), 3));
-            dexAllowance.setAllowanceUom(UnitMeasure.convertUnitMeasure(segment.getElement(7)));
+            dexAllowance.setAllowanceUom(UnitMeasure.convert(segment.getElement(7)));
             dexAllowance.setAllowanceAmount(ConversionUtil.convertStringToBigDecimal(segment.getElement(8), 2));
             dexAllowance.setAllowancePercent(ConversionUtil.convertStringToBigDecimal(segment.getElement(9), 3));
             dexAllowance.setOptionNumber(segment.getElement(10));

--- a/src/main/java/com/walmartlabs/x12/dex/dx894/DefaultDex894Validator.java
+++ b/src/main/java/com/walmartlabs/x12/dex/dx894/DefaultDex894Validator.java
@@ -16,9 +16,10 @@ limitations under the License.
 package com.walmartlabs.x12.dex.dx894;
 
 import com.walmartlabs.x12.X12Validator;
-import com.walmartlabs.x12.crc.CyclicRedundancyCheck;
-import com.walmartlabs.x12.crc.DefaultCrc16;
 import com.walmartlabs.x12.exceptions.X12ErrorDetail;
+import com.walmartlabs.x12.types.UnitMeasure;
+import com.walmartlabs.x12.util.crc.CyclicRedundancyCheck;
+import com.walmartlabs.x12.util.crc.DefaultCrc16;
 import org.springframework.util.StringUtils;
 
 import java.util.HashSet;

--- a/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894Allowance.java
+++ b/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894Allowance.java
@@ -15,6 +15,8 @@ limitations under the License.
  */
 package com.walmartlabs.x12.dex.dx894;
 
+import com.walmartlabs.x12.types.UnitMeasure;
+
 import java.math.BigDecimal;
 
 public class Dex894Allowance {

--- a/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894Item.java
+++ b/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894Item.java
@@ -15,6 +15,9 @@ limitations under the License.
  */
 package com.walmartlabs.x12.dex.dx894;
 
+import com.walmartlabs.x12.types.ProductQualifier;
+import com.walmartlabs.x12.types.UnitMeasure;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/dex/dx894/Dex894TransactionSet.java
@@ -16,6 +16,7 @@ limitations under the License.
 package com.walmartlabs.x12.dex.dx894;
 
 import com.walmartlabs.x12.AbstractX12TransactionSet;
+import com.walmartlabs.x12.types.InvoiceType;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/src/main/java/com/walmartlabs/x12/po850/DefaultPo850TransactionSetParser.java
+++ b/src/main/java/com/walmartlabs/x12/po850/DefaultPo850TransactionSetParser.java
@@ -1,0 +1,24 @@
+package com.walmartlabs.x12.po850;
+
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.standard.AbstractTransactionSetParserChainable;
+import com.walmartlabs.x12.standard.X12Group;
+
+import java.util.List;
+
+public class DefaultPo850TransactionSetParser extends AbstractTransactionSetParserChainable {
+
+    @Override
+    protected boolean handlesTransactionSet(List<X12Segment> transactionSegments, X12Group x12Group) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    protected X12TransactionSet doParse(List<X12Segment> transactionSegments, X12Group x12Group) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/src/main/java/com/walmartlabs/x12/standard/StandardX12Parser.java
+++ b/src/main/java/com/walmartlabs/x12/standard/StandardX12Parser.java
@@ -15,13 +15,13 @@ limitations under the License.
  */
 package com.walmartlabs.x12.standard;
 
+import com.walmartlabs.x12.SegmentIterator;
 import com.walmartlabs.x12.X12Parser;
+import com.walmartlabs.x12.X12ParsingUtil;
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.X12TransactionSet;
 import com.walmartlabs.x12.exceptions.X12ParserException;
 import com.walmartlabs.x12.util.ConversionUtil;
-import com.walmartlabs.x12.util.SegmentIterator;
-import com.walmartlabs.x12.util.X12ParsingUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
@@ -203,17 +203,17 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
                 // get the next segment
                 currentSegment = segments.next();
 
-                if (X12TransactionSet.TRANSACTION_SET_HEADER.equals(currentSegment.getSegmentIdentifier())) {
+                if (X12TransactionSet.TRANSACTION_SET_HEADER.equals(currentSegment.getIdentifier())) {
                     if (insideTransaction) {
                         // we are already in a transaction
                         // and have not encountered the end
                         // so we will stop parsing
-                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getSegmentIdentifier());
+                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
                     } else {
                         insideTransaction = true;
                         transactionSet.add(currentSegment);
                     }
-                } else if (X12TransactionSet.TRANSACTION_SET_TRAILER.equals(currentSegment.getSegmentIdentifier())) {
+                } else if (X12TransactionSet.TRANSACTION_SET_TRAILER.equals(currentSegment.getIdentifier())) {
                     if (insideTransaction) {
                         transactionSet.add(currentSegment);
                         // delegate parsing of transaction set
@@ -224,14 +224,14 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
                     } else {
                         // we are not in a transaction
                         // so should not have gotten transaction trailer
-                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_HEADER, currentSegment.getSegmentIdentifier());
+                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_HEADER, currentSegment.getIdentifier());
                     }
-                } else if (GROUP_TRAILER_ID.equals(currentSegment.getSegmentIdentifier())) {
+                } else if (GROUP_TRAILER_ID.equals(currentSegment.getIdentifier())) {
                     if (insideTransaction) {
                         // we are already in a transaction
                         // and have not encountered the end
                         // so we will stop parsing
-                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getSegmentIdentifier());
+                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
                     } else {
                         insideGroup = false;
                     }
@@ -244,13 +244,13 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
             // if we got here we should have cleanly
             // exited a transaction
             if (insideTransaction) {
-                handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getSegmentIdentifier());
+                handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
             }
 
             // if we got here we should have cleanly
             // exited a group
             if (insideGroup) {
-                handleUnexpectedSegment(GROUP_TRAILER_ID, currentSegment.getSegmentIdentifier());
+                handleUnexpectedSegment(GROUP_TRAILER_ID, currentSegment.getIdentifier());
             }
 
             // parse group trailer
@@ -259,7 +259,7 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
             // check for end of message
             if (segments.hasNext()) {
                 currentSegment = segments.next();
-                if (ISA_TRAILER_ID.equals(currentSegment.getSegmentIdentifier())) {
+                if (ISA_TRAILER_ID.equals(currentSegment.getIdentifier())) {
                     this.parseInterchangeControlTrailer(currentSegment, x12Doc);
                 } else {
                     // move back one
@@ -278,27 +278,27 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
      * @param x12Doc
      */
     private void parseInterchangeControlHeader(X12Segment segment, StandardX12Document x12Doc) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (ISA_HEADER_ID.equals(segmentIdentifier)) {
             InterchangeControlEnvelope isa = new InterchangeControlEnvelope();
-            isa.setAuthorizationInformationQualifier(segment.getSegmentElement(1));
-            isa.setAuthorizationInformation(segment.getSegmentElement(2));
-            isa.setSecurityInformationQualifier(segment.getSegmentElement(3));
-            isa.setSecurityInformation(segment.getSegmentElement(4));
-            isa.setInterchangeIdQualifier(segment.getSegmentElement(5));
-            isa.setInterchangeSenderId(segment.getSegmentElement(6));
-            isa.setInterchangeIdQualifier_2(segment.getSegmentElement(7));
-            isa.setInterchangeReceiverId(segment.getSegmentElement(8));
-            isa.setInterchangeDate(segment.getSegmentElement(9));
-            isa.setInterchangeTime(segment.getSegmentElement(10));
-            isa.setInterchangeControlStandardId(segment.getSegmentElement(11));
-            isa.setInterchangeControlVersion(segment.getSegmentElement(12));
-            isa.setInterchangeControlNumber(segment.getSegmentElement(13));
-            isa.setAcknowledgementRequested(segment.getSegmentElement(14));
-            isa.setUsageIndicator(segment.getSegmentElement(15));
-            isa.setElementSeparator(segment.getSegmentElement(16));
+            isa.setAuthorizationInformationQualifier(segment.getElement(1));
+            isa.setAuthorizationInformation(segment.getElement(2));
+            isa.setSecurityInformationQualifier(segment.getElement(3));
+            isa.setSecurityInformation(segment.getElement(4));
+            isa.setInterchangeIdQualifier(segment.getElement(5));
+            isa.setInterchangeSenderId(segment.getElement(6));
+            isa.setInterchangeIdQualifier_2(segment.getElement(7));
+            isa.setInterchangeReceiverId(segment.getElement(8));
+            isa.setInterchangeDate(segment.getElement(9));
+            isa.setInterchangeTime(segment.getElement(10));
+            isa.setInterchangeControlStandardId(segment.getElement(11));
+            isa.setInterchangeControlVersion(segment.getElement(12));
+            isa.setInterchangeControlNumber(segment.getElement(13));
+            isa.setAcknowledgementRequested(segment.getElement(14));
+            isa.setUsageIndicator(segment.getElement(15));
+            isa.setElementSeparator(segment.getElement(16));
 
             x12Doc.setInterchangeControlEnvelope(isa);
         } else {
@@ -313,13 +313,13 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
      * @param x12Doc
      */
     private void parseInterchangeControlTrailer(X12Segment segment, StandardX12Document x12Doc) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (ISA_TRAILER_ID.equals(segmentIdentifier)) {
             InterchangeControlEnvelope isa = x12Doc.getInterchangeControlEnvelope();
-            isa.setNumberOfGroups(ConversionUtil.convertStringToInteger(segment.getSegmentElement(1)));
-            isa.setTrailerInterchangeControlNumber(segment.getSegmentElement(2));
+            isa.setNumberOfGroups(ConversionUtil.convertStringToInteger(segment.getElement(1)));
+            isa.setTrailerInterchangeControlNumber(segment.getElement(2));
         } else {
             handleUnexpectedSegment(ISA_TRAILER_ID, segmentIdentifier);
         }
@@ -332,20 +332,20 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
      * @param x12Doc
      */
     private X12Group parseGroupHeader(X12Segment segment, StandardX12Document x12Doc) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
         X12Group groupHeader = null;
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (GROUP_HEADER_ID.equals(segmentIdentifier)) {
             groupHeader = new X12Group();
-            groupHeader.setFunctionalCodeId(segment.getSegmentElement(1));
-            groupHeader.setApplicationSenderCode(segment.getSegmentElement(2));
-            groupHeader.setApplicationReceiverCode(segment.getSegmentElement(3));
-            groupHeader.setDate(segment.getSegmentElement(4));
-            groupHeader.setTime(segment.getSegmentElement(5));
-            groupHeader.setHeaderGroupControlNumber(segment.getSegmentElement(6));
-            groupHeader.setResponsibleAgencyCode(segment.getSegmentElement(7));
-            groupHeader.setVersion(segment.getSegmentElement(8));
+            groupHeader.setFunctionalCodeId(segment.getElement(1));
+            groupHeader.setApplicationSenderCode(segment.getElement(2));
+            groupHeader.setApplicationReceiverCode(segment.getElement(3));
+            groupHeader.setDate(segment.getElement(4));
+            groupHeader.setTime(segment.getElement(5));
+            groupHeader.setHeaderGroupControlNumber(segment.getElement(6));
+            groupHeader.setResponsibleAgencyCode(segment.getElement(7));
+            groupHeader.setVersion(segment.getElement(8));
         } else {
             handleUnexpectedSegment(GROUP_HEADER_ID, segmentIdentifier);
         }
@@ -358,12 +358,12 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
      * @param x12Doc
      */
     private void parseGroupTrailer(X12Segment segment, X12Group x12Group) {
-        LOGGER.debug(segment.getSegmentIdentifier());
+        LOGGER.debug(segment.getIdentifier());
 
-        String segmentIdentifier = segment.getSegmentIdentifier();
+        String segmentIdentifier = segment.getIdentifier();
         if (GROUP_TRAILER_ID.equals(segmentIdentifier)) {
-            x12Group.setNumberOfTransactions(ConversionUtil.convertStringToInteger(segment.getSegmentElement(1)));
-            x12Group.setTrailerGroupControlNumber(segment.getSegmentElement(2));
+            x12Group.setNumberOfTransactions(ConversionUtil.convertStringToInteger(segment.getElement(1)));
+            x12Group.setTrailerGroupControlNumber(segment.getElement(2));
         } else {
             handleUnexpectedSegment(GROUP_TRAILER_ID, segmentIdentifier);
         }

--- a/src/main/java/com/walmartlabs/x12/types/InvoiceType.java
+++ b/src/main/java/com/walmartlabs/x12/types/InvoiceType.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.dex.dx894;
+package com.walmartlabs.x12.types;
 
 /**
  * represents the G8201 - debit/credit flag

--- a/src/main/java/com/walmartlabs/x12/types/ProductQualifier.java
+++ b/src/main/java/com/walmartlabs/x12/types/ProductQualifier.java
@@ -13,31 +13,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.dex.dx894;
+package com.walmartlabs.x12.types;
 
 /**
- * represents the G8303 - unit of measure code set of values
- *
+ * product/service id qualifier values
+ * used on DEX G8305
+ * used on ASN SN103
  */
-public enum UnitMeasure {
-    BX("BOX"),
-    CA("CASE"),
-    CT("CARTON"),
-    EA("EACH"),
-    DZ("DOZEN"),
-    GA("GALLON"),
-    KE("KEG"),
-    KG("KILOGRAM"),
-    LB("POUND"),
-    PK("PACKAGE"),
-    PL("PALLET"),
-    TK("TANK"),
-    UN("UNIT"),
+public enum ProductQualifier {
+    DI("DEPOSIT ITEM NUMBER"),
+    EN("EAN/UCC-13"),
+    EO("EAN/UCC-8"),
+    NR("NONRESALABLE ITEM"),
+    UK("EAN/UCC-14"),
+    UP("EAN/UCC-12"),
+    VN("VENDOR ITEM NUMBER"),
     UNKNOWN("UNKNOWN");
 
     private String description;
 
-    private UnitMeasure(String desc) {
+    private ProductQualifier(String desc) {
         this.description = desc;
     }
 
@@ -47,17 +42,17 @@ public enum UnitMeasure {
 
     /**
      * Convert the unit of measure value to an enum
-     * @param uom
+     * @param productQualifierCode
      * @return
      */
-    public static UnitMeasure convertUnitMeasure(String uom) {
-        if (uom == null) {
+    public static ProductQualifier convertProductQualifier(String productQualifierCode) {
+        if (productQualifierCode == null) {
             return null;
         } else {
-            UnitMeasure returnEnum = UnitMeasure.UNKNOWN;
+            ProductQualifier returnEnum = ProductQualifier.UNKNOWN;
 
             try {
-                returnEnum = UnitMeasure.valueOf(uom);
+                returnEnum = ProductQualifier.valueOf(productQualifierCode);
             } catch (Exception e) {
                 // illegal value so returning UNKNOWN
             }

--- a/src/main/java/com/walmartlabs/x12/types/ProductQualifier.java
+++ b/src/main/java/com/walmartlabs/x12/types/ProductQualifier.java
@@ -31,28 +31,33 @@ public enum ProductQualifier {
     UNKNOWN("UNKNOWN");
 
     private String description;
-
+    
     private ProductQualifier(String desc) {
         this.description = desc;
     }
 
+    private void setDescription(String desc) {
+        this.description = desc;
+    }
+    
     public String getDescription() {
         return this.description;
     }
 
     /**
-     * Convert the unit of measure value to an enum
-     * @param productQualifierCode
+     * Convert the code to an enum
+     * @param code
      * @return
      */
-    public static ProductQualifier convertProductQualifier(String productQualifierCode) {
-        if (productQualifierCode == null) {
+    public static ProductQualifier convert(String code) {
+        if (code == null) {
             return null;
         } else {
             ProductQualifier returnEnum = ProductQualifier.UNKNOWN;
+            returnEnum.setDescription(code);
 
             try {
-                returnEnum = ProductQualifier.valueOf(productQualifierCode);
+                returnEnum = ProductQualifier.valueOf(code);
             } catch (Exception e) {
                 // illegal value so returning UNKNOWN
             }

--- a/src/main/java/com/walmartlabs/x12/types/UnitMeasure.java
+++ b/src/main/java/com/walmartlabs/x12/types/UnitMeasure.java
@@ -13,25 +13,32 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.dex.dx894;
+package com.walmartlabs.x12.types;
 
 /**
- * represents the G8305 - product/service id qualifier values
- *
+ * unit of measure code set of values
+ * used on DEX G8303
+ * used on ASN LIN08
  */
-public enum ProductQualifier {
-    DI("DEPOSIT ITEM NUMBER"),
-    EN("EAN/UCC-13"),
-    EO("EAN/UCC-8"),
-    NR("NONRESALABLE ITEM"),
-    UK("EAN/UCC-14"),
-    UP("EAN/UCC-12"),
-    VN("VENDOR ITEM NUMBER"),
+public enum UnitMeasure {
+    BX("BOX"),
+    CA("CASE"),
+    CT("CARTON"),
+    EA("EACH"),
+    DZ("DOZEN"),
+    GA("GALLON"),
+    KE("KEG"),
+    KG("KILOGRAM"),
+    LB("POUND"),
+    PK("PACKAGE"),
+    PL("PALLET"),
+    TK("TANK"),
+    UN("UNIT"),
     UNKNOWN("UNKNOWN");
 
     private String description;
 
-    private ProductQualifier(String desc) {
+    private UnitMeasure(String desc) {
         this.description = desc;
     }
 
@@ -41,17 +48,17 @@ public enum ProductQualifier {
 
     /**
      * Convert the unit of measure value to an enum
-     * @param productQualifierCode
+     * @param uom
      * @return
      */
-    public static ProductQualifier convertProductQualifier(String productQualifierCode) {
-        if (productQualifierCode == null) {
+    public static UnitMeasure convertUnitMeasure(String uom) {
+        if (uom == null) {
             return null;
         } else {
-            ProductQualifier returnEnum = ProductQualifier.UNKNOWN;
+            UnitMeasure returnEnum = UnitMeasure.UNKNOWN;
 
             try {
-                returnEnum = ProductQualifier.valueOf(productQualifierCode);
+                returnEnum = UnitMeasure.valueOf(uom);
             } catch (Exception e) {
                 // illegal value so returning UNKNOWN
             }

--- a/src/main/java/com/walmartlabs/x12/types/UnitMeasure.java
+++ b/src/main/java/com/walmartlabs/x12/types/UnitMeasure.java
@@ -42,23 +42,28 @@ public enum UnitMeasure {
         this.description = desc;
     }
 
+    private void setDescription(String desc) {
+        this.description = desc;
+    }
+    
     public String getDescription() {
         return this.description;
     }
 
     /**
-     * Convert the unit of measure value to an enum
-     * @param uom
+     * Convert the code to an enum
+     * @param code
      * @return
      */
-    public static UnitMeasure convertUnitMeasure(String uom) {
-        if (uom == null) {
+    public static UnitMeasure convert(String code) {
+        if (code == null) {
             return null;
         } else {
             UnitMeasure returnEnum = UnitMeasure.UNKNOWN;
+            returnEnum.setDescription(code);
 
             try {
-                returnEnum = UnitMeasure.valueOf(uom);
+                returnEnum = UnitMeasure.valueOf(code);
             } catch (Exception e) {
                 // illegal value so returning UNKNOWN
             }

--- a/src/main/java/com/walmartlabs/x12/types/WeightQualifier.java
+++ b/src/main/java/com/walmartlabs/x12/types/WeightQualifier.java
@@ -16,28 +16,42 @@ limitations under the License.
 package com.walmartlabs.x12.types;
 
 /**
- * debit/credit flag
- * used on the DEX G8201 
+ * Weight Qualifier
  *
  */
-public enum InvoiceType {
-    C, // CREDIT
-    D, // DEBIT
-    UNKNOWN;
+public enum WeightQualifier {
+    G("GROSS WEIGHT"),
+    N("ACTUAL_NET_WEIGHT"),
+    UNKNOWN("");
 
+    private String description;
+    
+    private WeightQualifier(String desc) {
+        this.description = desc;
+    }
+    
+    private void setDescription(String desc) {
+        this.description = desc;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+    
     /**
      * Convert the code to an enum
      * @param code
      * @return
      */
-    public static InvoiceType convert(String code) {
+    public static WeightQualifier convert(String code) {
         if (code == null) {
             return null;
         } else {
-            InvoiceType returnEnum = InvoiceType.UNKNOWN;
+            WeightQualifier returnEnum = WeightQualifier.UNKNOWN;
+            returnEnum.setDescription(code);
 
             try {
-                returnEnum = InvoiceType.valueOf(code);
+                returnEnum = WeightQualifier.valueOf(code);
             } catch (Exception e) {
                 // illegal value so returning UNKNOWN
             }

--- a/src/main/java/com/walmartlabs/x12/util/RetailSellingUnitUtil.java
+++ b/src/main/java/com/walmartlabs/x12/util/RetailSellingUnitUtil.java
@@ -15,8 +15,8 @@ limitations under the License.
  */
 package com.walmartlabs.x12.util;
 
-import com.walmartlabs.x12.checksum.BarCodeMod10Checksum;
-import com.walmartlabs.x12.checksum.Checksum;
+import com.walmartlabs.x12.util.checksum.BarCodeMod10Checksum;
+import com.walmartlabs.x12.util.checksum.Checksum;
 
 public class RetailSellingUnitUtil {
 

--- a/src/main/java/com/walmartlabs/x12/util/checksum/BarCodeMod10Checksum.java
+++ b/src/main/java/com/walmartlabs/x12/util/checksum/BarCodeMod10Checksum.java
@@ -13,45 +13,44 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.checksum;
+package com.walmartlabs.x12.util.checksum;
 
-public class LuhnMod10Checksum implements Checksum {
+public class BarCodeMod10Checksum implements Checksum {
 
-    private static final int NINE = 9;
+    private static final int THREE = 3;
     private static final int TEN = 10;
 
-    @Override
     /**
-     * Luhn algorithm (Modulo 10) to generate checksum digit
+     * Yet another Modulo 10 to generate checksum digit
      * This implementation assumes that there is NO checksum digit
      * included in the number provided
-     * https://en.wikipedia.org/wiki/Luhn_algorithm
+     * https://www.activebarcode.com/codes/checkdigit/modulo10.html
+     * https://www.idautomation.com/barcode-faq/upc-ean/#MOD_10
      * @param number
-     * @return the checksum digit
+     * @return
      */
+    @Override
     public String generateChecksumDigit(String number) {
         if (number != null && number.length() > 0) {
             // work from rightmost digit
             StringBuilder sb = new StringBuilder(number);
             String reversedNumber = sb.reverse().toString();
             char[] val = reversedNumber.toCharArray();
-            int sum = 0;
+            int even = 0;
+            int odd = 0;
             for (int i = 0; i < val.length; i++) {
                 int currentVal = Integer.parseInt(String.valueOf(val[i]));
-                int calcVal = currentVal;
                 if (i % 2 == 0) {
-                    // double every other digit
-                    // starting with rightmost digit
-                    int product = currentVal * 2;
-                    if (product > NINE) {
-                        calcVal = product - NINE;
-                    } else {
-                        calcVal = product;
-                    }
+                    even = currentVal + even;
+                } else {
+                    odd = currentVal + odd;
                 }
-                sum += calcVal;
             }
-            int cd = (sum * NINE) % TEN;
+            int cd = ((even * THREE) + odd) % TEN;
+            if (cd != 0) {
+                cd = TEN - cd;
+            }
+
             return Integer.toString(cd);
         } else {
             return null;

--- a/src/main/java/com/walmartlabs/x12/util/checksum/Checksum.java
+++ b/src/main/java/com/walmartlabs/x12/util/checksum/Checksum.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.checksum;
+package com.walmartlabs.x12.util.checksum;
 
 public interface Checksum {
     /**

--- a/src/main/java/com/walmartlabs/x12/util/checksum/LuhnMod10Checksum.java
+++ b/src/main/java/com/walmartlabs/x12/util/checksum/LuhnMod10Checksum.java
@@ -13,44 +13,45 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.checksum;
+package com.walmartlabs.x12.util.checksum;
 
-public class BarCodeMod10Checksum implements Checksum {
+public class LuhnMod10Checksum implements Checksum {
 
-    private static final int THREE = 3;
+    private static final int NINE = 9;
     private static final int TEN = 10;
 
+    @Override
     /**
-     * Yet another Modulo 10 to generate checksum digit
+     * Luhn algorithm (Modulo 10) to generate checksum digit
      * This implementation assumes that there is NO checksum digit
      * included in the number provided
-     * https://www.activebarcode.com/codes/checkdigit/modulo10.html
-     * https://www.idautomation.com/barcode-faq/upc-ean/#MOD_10
+     * https://en.wikipedia.org/wiki/Luhn_algorithm
      * @param number
-     * @return
+     * @return the checksum digit
      */
-    @Override
     public String generateChecksumDigit(String number) {
         if (number != null && number.length() > 0) {
             // work from rightmost digit
             StringBuilder sb = new StringBuilder(number);
             String reversedNumber = sb.reverse().toString();
             char[] val = reversedNumber.toCharArray();
-            int even = 0;
-            int odd = 0;
+            int sum = 0;
             for (int i = 0; i < val.length; i++) {
                 int currentVal = Integer.parseInt(String.valueOf(val[i]));
+                int calcVal = currentVal;
                 if (i % 2 == 0) {
-                    even = currentVal + even;
-                } else {
-                    odd = currentVal + odd;
+                    // double every other digit
+                    // starting with rightmost digit
+                    int product = currentVal * 2;
+                    if (product > NINE) {
+                        calcVal = product - NINE;
+                    } else {
+                        calcVal = product;
+                    }
                 }
+                sum += calcVal;
             }
-            int cd = ((even * THREE) + odd) % TEN;
-            if (cd != 0) {
-                cd = TEN - cd;
-            }
-
+            int cd = (sum * NINE) % TEN;
             return Integer.toString(cd);
         } else {
             return null;

--- a/src/main/java/com/walmartlabs/x12/util/crc/CyclicRedundancyCheck.java
+++ b/src/main/java/com/walmartlabs/x12/util/crc/CyclicRedundancyCheck.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.crc;
+package com.walmartlabs.x12.util.crc;
 
 public interface CyclicRedundancyCheck {
     /**

--- a/src/main/java/com/walmartlabs/x12/util/crc/DefaultCrc16.java
+++ b/src/main/java/com/walmartlabs/x12/util/crc/DefaultCrc16.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.crc;
+package com.walmartlabs.x12.util.crc;
 
 /**
  * CRC-16 Uses irreducible polynomial: 1 + x^2 + x^15 + x^16

--- a/src/test/java/com/walmartlabs/x12/SegmentIteratorTest.java
+++ b/src/test/java/com/walmartlabs/x12/SegmentIteratorTest.java
@@ -1,5 +1,6 @@
-package com.walmartlabs.x12.util;
+package com.walmartlabs.x12;
 
+import com.walmartlabs.x12.SegmentIterator;
 import com.walmartlabs.x12.X12Segment;
 import org.junit.Test;
 
@@ -46,14 +47,14 @@ public class SegmentIteratorTest {
         assertEquals(0, iter.nextIndex());
         X12Segment segment = iter.next();
         assertNotNull(segment);
-        assertEquals("LINE1", segment.getSegmentElement(0));
+        assertEquals("LINE1", segment.getElement(0));
 
         // advance again
         assertTrue(iter.hasNext());
         assertEquals(1, iter.nextIndex());
         segment = iter.next();
         assertNotNull(segment);
-        assertEquals("LINE2", segment.getSegmentElement(0));
+        assertEquals("LINE2", segment.getElement(0));
 
         // advance again
         assertFalse(iter.hasNext());
@@ -76,28 +77,28 @@ public class SegmentIteratorTest {
         assertEquals(0, iter.nextIndex());
         X12Segment segment = iter.next();
         assertNotNull(segment);
-        assertEquals("LINE1", segment.getSegmentElement(0));
+        assertEquals("LINE1", segment.getElement(0));
 
         // advance again
         assertTrue(iter.hasNext());
         assertEquals(1, iter.nextIndex());
         segment = iter.next();
         assertNotNull(segment);
-        assertEquals("LINE2", segment.getSegmentElement(0));
+        assertEquals("LINE2", segment.getElement(0));
 
         // previous
         assertTrue(iter.hasPrevious());
         assertEquals(1, iter.previousIndex());
         segment = iter.previous();
         assertNotNull(segment);
-        assertEquals("LINE2", segment.getSegmentElement(0));
+        assertEquals("LINE2", segment.getElement(0));
 
         // previous again
         assertTrue(iter.hasPrevious());
         assertEquals(0, iter.previousIndex());
         segment = iter.previous();
         assertNotNull(segment);
-        assertEquals("LINE1", segment.getSegmentElement(0));
+        assertEquals("LINE1", segment.getElement(0));
 
     }
 

--- a/src/test/java/com/walmartlabs/x12/X12ParsingUtilTest.java
+++ b/src/test/java/com/walmartlabs/x12/X12ParsingUtilTest.java
@@ -13,8 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.util;
+package com.walmartlabs.x12;
 
+import com.walmartlabs.x12.X12ParsingUtil;
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.exceptions.X12ParserException;
 import com.walmartlabs.x12.standard.X12Loop;
@@ -73,8 +74,8 @@ public class X12ParsingUtilTest {
         List<X12Segment> segmentsInLoop = loop.getSegments();
         assertNotNull(segmentsInLoop);
         assertEquals(2, segmentsInLoop.size());
-        assertEquals("DTM", segmentsInLoop.get(0).getSegmentIdentifier());
-        assertEquals("TD3", segmentsInLoop.get(1).getSegmentIdentifier());
+        assertEquals("DTM", segmentsInLoop.get(0).getIdentifier());
+        assertEquals("TD3", segmentsInLoop.get(1).getIdentifier());
         
         List<X12Loop> childLoops = loop.getChildLoops();
         assertNull(childLoops);
@@ -124,8 +125,8 @@ public class X12ParsingUtilTest {
         List<X12Segment> segmentsInShipmentLoop = shipmentLoop.getSegments();
         assertNotNull(segmentsInShipmentLoop);
         assertEquals(2, segmentsInShipmentLoop.size());
-        assertEquals("DTM", segmentsInShipmentLoop.get(0).getSegmentIdentifier());
-        assertEquals("TD3", segmentsInShipmentLoop.get(1).getSegmentIdentifier());
+        assertEquals("DTM", segmentsInShipmentLoop.get(0).getIdentifier());
+        assertEquals("TD3", segmentsInShipmentLoop.get(1).getIdentifier());
         
         List<X12Loop> childrenOfShipmentLoop = shipmentLoop.getChildLoops();
         assertNotNull(childrenOfShipmentLoop);
@@ -141,9 +142,9 @@ public class X12ParsingUtilTest {
         List<X12Segment> segmentsInOrderLoop = orderLoop.getSegments();
         assertNotNull(segmentsInOrderLoop);
         assertEquals(2, segmentsInOrderLoop.size());
-        assertEquals("PRF", segmentsInOrderLoop.get(0).getSegmentIdentifier());
-        assertEquals("222", segmentsInOrderLoop.get(0).getSegmentElement(1));
-        assertEquals("REF", segmentsInOrderLoop.get(1).getSegmentIdentifier());
+        assertEquals("PRF", segmentsInOrderLoop.get(0).getIdentifier());
+        assertEquals("222", segmentsInOrderLoop.get(0).getElement(1));
+        assertEquals("REF", segmentsInOrderLoop.get(1).getIdentifier());
         
         assertNull(orderLoop.getChildLoops());
         
@@ -157,9 +158,9 @@ public class X12ParsingUtilTest {
         segmentsInOrderLoop = orderLoop.getSegments();
         assertNotNull(segmentsInOrderLoop);
         assertEquals(2, segmentsInOrderLoop.size());
-        assertEquals("PRF", segmentsInOrderLoop.get(0).getSegmentIdentifier());
-        assertEquals("333", segmentsInOrderLoop.get(0).getSegmentElement(1));
-        assertEquals("REF", segmentsInOrderLoop.get(1).getSegmentIdentifier());
+        assertEquals("PRF", segmentsInOrderLoop.get(0).getIdentifier());
+        assertEquals("333", segmentsInOrderLoop.get(0).getElement(1));
+        assertEquals("REF", segmentsInOrderLoop.get(1).getIdentifier());
         
         List<X12Loop>childrenOfOrderLoop = orderLoop.getChildLoops();
         assertNotNull(childrenOfOrderLoop);
@@ -175,7 +176,7 @@ public class X12ParsingUtilTest {
         List<X12Segment> segmentsInPackLoop = packLoop.getSegments();
         assertNotNull(segmentsInPackLoop);
         assertEquals(1, segmentsInPackLoop.size());
-        assertEquals("MAN", segmentsInPackLoop.get(0).getSegmentIdentifier());
+        assertEquals("MAN", segmentsInPackLoop.get(0).getIdentifier());
         
         assertNull(packLoop.getChildLoops());
     }
@@ -272,9 +273,9 @@ public class X12ParsingUtilTest {
         List<X12Segment> segmentsInLoop = loop.getSegments();
         assertNotNull(segmentsInLoop);
         assertEquals(2, segmentsInLoop.size());
-        assertEquals("DTM", segmentsInLoop.get(0).getSegmentIdentifier());
-        assertEquals("TD3", segmentsInLoop.get(1).getSegmentIdentifier());
-        assertEquals("A", segmentsInLoop.get(1).getSegmentElement(1));
+        assertEquals("DTM", segmentsInLoop.get(0).getIdentifier());
+        assertEquals("TD3", segmentsInLoop.get(1).getIdentifier());
+        assertEquals("A", segmentsInLoop.get(1).getElement(1));
         
         List<X12Loop> childLoops = loop.getChildLoops();
         assertNull(childLoops);
@@ -289,8 +290,8 @@ public class X12ParsingUtilTest {
         segmentsInLoop = loop.getSegments();
         assertNotNull(segmentsInLoop);
         assertEquals(1, segmentsInLoop.size());
-        assertEquals("TD3", segmentsInLoop.get(0).getSegmentIdentifier());
-        assertEquals("B", segmentsInLoop.get(0).getSegmentElement(1));
+        assertEquals("TD3", segmentsInLoop.get(0).getIdentifier());
+        assertEquals("B", segmentsInLoop.get(0).getElement(1));
         
         childLoops = loop.getChildLoops();
         assertNull(childLoops);

--- a/src/test/java/com/walmartlabs/x12/X12SegmentTest.java
+++ b/src/test/java/com/walmartlabs/x12/X12SegmentTest.java
@@ -27,14 +27,14 @@ public class X12SegmentTest {
         X12Segment segment = new X12Segment("DXS*9251230013*DX*004010UCS*1*9254850000");
         assertNotNull(segment);
         assertEquals(6, segment.segmentSize());
-        assertEquals("DXS", segment.getSegmentIdentifier());
-        assertEquals("DXS", segment.getSegmentElement(0));
-        assertEquals("9251230013", segment.getSegmentElement(1));
-        assertEquals("DX", segment.getSegmentElement(2));
-        assertEquals("004010UCS", segment.getSegmentElement(3));
-        assertEquals("1", segment.getSegmentElement(4));
-        assertEquals("9254850000", segment.getSegmentElement(5));
-        assertEquals(null, segment.getSegmentElement(6));
+        assertEquals("DXS", segment.getIdentifier());
+        assertEquals("DXS", segment.getElement(0));
+        assertEquals("9251230013", segment.getElement(1));
+        assertEquals("DX", segment.getElement(2));
+        assertEquals("004010UCS", segment.getElement(3));
+        assertEquals("1", segment.getElement(4));
+        assertEquals("9254850000", segment.getElement(5));
+        assertEquals(null, segment.getElement(6));
     }
 
 
@@ -43,14 +43,14 @@ public class X12SegmentTest {
         X12Segment segment = new X12Segment("ST*9251230013*DX*004010UCS*1*9254850000");
         assertNotNull(segment);
         assertEquals(6, segment.segmentSize());
-        assertEquals("ST", segment.getSegmentIdentifier());
-        assertEquals("ST", segment.getSegmentElement(0));
-        assertEquals("9251230013", segment.getSegmentElement(1));
-        assertEquals("DX", segment.getSegmentElement(2));
-        assertEquals("004010UCS", segment.getSegmentElement(3));
-        assertEquals("1", segment.getSegmentElement(4));
-        assertEquals("9254850000", segment.getSegmentElement(5));
-        assertEquals(null, segment.getSegmentElement(6));
+        assertEquals("ST", segment.getIdentifier());
+        assertEquals("ST", segment.getElement(0));
+        assertEquals("9251230013", segment.getElement(1));
+        assertEquals("DX", segment.getElement(2));
+        assertEquals("004010UCS", segment.getElement(3));
+        assertEquals("1", segment.getElement(4));
+        assertEquals("9254850000", segment.getElement(5));
+        assertEquals(null, segment.getElement(6));
     }
 
     @Test
@@ -58,15 +58,15 @@ public class X12SegmentTest {
         X12Segment segment = new X12Segment("*ST*9251230013*DX*004010UCS*1*9254850000");
         assertNotNull(segment);
         assertEquals(7, segment.segmentSize());
-        assertEquals("", segment.getSegmentIdentifier());
-        assertEquals(null, segment.getSegmentElement(0));
-        assertEquals("ST", segment.getSegmentElement(1));
-        assertEquals("9251230013", segment.getSegmentElement(2));
-        assertEquals("DX", segment.getSegmentElement(3));
-        assertEquals("004010UCS", segment.getSegmentElement(4));
-        assertEquals("1", segment.getSegmentElement(5));
-        assertEquals("9254850000", segment.getSegmentElement(6));
-        assertEquals(null, segment.getSegmentElement(7));
+        assertEquals("", segment.getIdentifier());
+        assertEquals(null, segment.getElement(0));
+        assertEquals("ST", segment.getElement(1));
+        assertEquals("9251230013", segment.getElement(2));
+        assertEquals("DX", segment.getElement(3));
+        assertEquals("004010UCS", segment.getElement(4));
+        assertEquals("1", segment.getElement(5));
+        assertEquals("9254850000", segment.getElement(6));
+        assertEquals(null, segment.getElement(7));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class X12SegmentTest {
         X12Segment segment = new X12Segment("TESTING 123");
         assertNotNull(segment);
         assertEquals(1, segment.segmentSize());
-        assertEquals("TESTING 123", segment.getSegmentIdentifier());
+        assertEquals("TESTING 123", segment.getIdentifier());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class X12SegmentTest {
         X12Segment segment = new X12Segment("");
         assertNotNull(segment);
         assertEquals(0, segment.segmentSize());
-        assertEquals("", segment.getSegmentIdentifier());
+        assertEquals("", segment.getIdentifier());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class X12SegmentTest {
         X12Segment segment = new X12Segment(null);
         assertNotNull(segment);
         assertEquals(0, segment.segmentSize());
-        assertEquals("", segment.getSegmentIdentifier());
+        assertEquals("", segment.getIdentifier());
     }
 
 }

--- a/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ParseValidateTest.java
+++ b/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ParseValidateTest.java
@@ -16,6 +16,9 @@ limitations under the License.
 package com.walmartlabs.x12.dex.dx894;
 
 import com.walmartlabs.x12.exceptions.X12ErrorDetail;
+import com.walmartlabs.x12.types.InvoiceType;
+import com.walmartlabs.x12.types.ProductQualifier;
+import com.walmartlabs.x12.types.UnitMeasure;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ParserTransactionTest.java
+++ b/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ParserTransactionTest.java
@@ -17,6 +17,8 @@ package com.walmartlabs.x12.dex.dx894;
 
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.exceptions.X12ParserException;
+import com.walmartlabs.x12.types.InvoiceType;
+import com.walmartlabs.x12.types.UnitMeasure;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ValidatorTest.java
+++ b/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ValidatorTest.java
@@ -16,6 +16,8 @@ limitations under the License.
 package com.walmartlabs.x12.dex.dx894;
 
 import com.walmartlabs.x12.exceptions.X12ErrorDetail;
+import com.walmartlabs.x12.types.ProductQualifier;
+import com.walmartlabs.x12.types.UnitMeasure;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/walmartlabs/x12/standard/StandardX12ParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/StandardX12ParserTest.java
@@ -311,7 +311,7 @@ public class StandardX12ParserTest {
             public void unhandledTransactionSet(List<X12Segment> transactionSegments, X12Group x12Group) {
                 assertNotNull(transactionSegments);
                 assertFalse(transactionSegments.isEmpty());
-                String txSetId = transactionSegments.get(0).getSegmentElement(1);
+                String txSetId = transactionSegments.get(0).getElement(1);
                 assertEquals("YYZ", txSetId);
             }
         });

--- a/src/test/java/com/walmartlabs/x12/types/ProductQualifierTest.java
+++ b/src/test/java/com/walmartlabs/x12/types/ProductQualifierTest.java
@@ -24,22 +24,28 @@ public class ProductQualifierTest {
 
     @Test
     public void test_valid_value() {
-        assertEquals(ProductQualifier.EN, ProductQualifier.convertProductQualifier("EN"));
+        ProductQualifier pq = ProductQualifier.convert("EN");
+        assertEquals(ProductQualifier.EN, pq);
+        assertEquals("EAN/UCC-13", pq.getDescription());
     }
 
     @Test
     public void test_invalid_value() {
-        assertEquals(ProductQualifier.UNKNOWN, ProductQualifier.convertProductQualifier("BOGUS"));
+        ProductQualifier pq = ProductQualifier.convert("BOGUS");
+        assertEquals(ProductQualifier.UNKNOWN, pq);
+        assertEquals("BOGUS", pq.getDescription());
     }
 
     @Test
     public void test_invalid_empty() {
-        assertEquals(ProductQualifier.UNKNOWN, ProductQualifier.convertProductQualifier(""));
+        ProductQualifier pq = ProductQualifier.convert("");
+        assertEquals(ProductQualifier.UNKNOWN, pq);
+        assertEquals("", pq.getDescription());
     }
 
     @Test
     public void test_invalid_null() {
-        assertEquals(null, ProductQualifier.convertProductQualifier(null));
+        assertEquals(null, ProductQualifier.convert(null));
     }
 
 }

--- a/src/test/java/com/walmartlabs/x12/types/ProductQualifierTest.java
+++ b/src/test/java/com/walmartlabs/x12/types/ProductQualifierTest.java
@@ -13,32 +13,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.dex.dx894;
+package com.walmartlabs.x12.types;
 
+import com.walmartlabs.x12.types.ProductQualifier;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class UnitMeasureTest {
+public class ProductQualifierTest {
 
     @Test
     public void test_valid_value() {
-        assertEquals(UnitMeasure.BX, UnitMeasure.convertUnitMeasure("BX"));
+        assertEquals(ProductQualifier.EN, ProductQualifier.convertProductQualifier("EN"));
     }
 
     @Test
     public void test_invalid_value() {
-        assertEquals(UnitMeasure.UNKNOWN, UnitMeasure.convertUnitMeasure("BOGUS"));
+        assertEquals(ProductQualifier.UNKNOWN, ProductQualifier.convertProductQualifier("BOGUS"));
     }
 
     @Test
     public void test_invalid_empty() {
-        assertEquals(UnitMeasure.UNKNOWN, UnitMeasure.convertUnitMeasure(""));
+        assertEquals(ProductQualifier.UNKNOWN, ProductQualifier.convertProductQualifier(""));
     }
 
     @Test
     public void test_invalid_null() {
-        assertEquals(null, UnitMeasure.convertUnitMeasure(null));
+        assertEquals(null, ProductQualifier.convertProductQualifier(null));
     }
 
 }

--- a/src/test/java/com/walmartlabs/x12/types/UnitMeasureTest.java
+++ b/src/test/java/com/walmartlabs/x12/types/UnitMeasureTest.java
@@ -13,32 +13,32 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.dex.dx894;
+package com.walmartlabs.x12.types;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ProductQualifierTest {
+public class UnitMeasureTest {
 
     @Test
     public void test_valid_value() {
-        assertEquals(ProductQualifier.EN, ProductQualifier.convertProductQualifier("EN"));
+        assertEquals(UnitMeasure.BX, UnitMeasure.convertUnitMeasure("BX"));
     }
 
     @Test
     public void test_invalid_value() {
-        assertEquals(ProductQualifier.UNKNOWN, ProductQualifier.convertProductQualifier("BOGUS"));
+        assertEquals(UnitMeasure.UNKNOWN, UnitMeasure.convertUnitMeasure("BOGUS"));
     }
 
     @Test
     public void test_invalid_empty() {
-        assertEquals(ProductQualifier.UNKNOWN, ProductQualifier.convertProductQualifier(""));
+        assertEquals(UnitMeasure.UNKNOWN, UnitMeasure.convertUnitMeasure(""));
     }
 
     @Test
     public void test_invalid_null() {
-        assertEquals(null, ProductQualifier.convertProductQualifier(null));
+        assertEquals(null, UnitMeasure.convertUnitMeasure(null));
     }
 
 }

--- a/src/test/java/com/walmartlabs/x12/types/WeightQualifierTest.java
+++ b/src/test/java/com/walmartlabs/x12/types/WeightQualifierTest.java
@@ -17,29 +17,29 @@ package com.walmartlabs.x12.types;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-public class UnitMeasureTest {
+public class WeightQualifierTest {
 
     @Test
     public void test_valid_value() {
-        UnitMeasure um = UnitMeasure.convert("BX");
-        assertEquals(UnitMeasure.BX, um);
-        assertEquals("BOX", um.getDescription());
+        WeightQualifier wq = WeightQualifier.convert("N");
+        assertEquals(WeightQualifier.N, wq);
+        assertEquals("ACTUAL_NET_WEIGHT", wq.getDescription());
     }
 
     @Test
     public void test_invalid_value() {
-        UnitMeasure um = UnitMeasure.convert("BOGUS");
-        assertEquals(UnitMeasure.UNKNOWN, um);
-        assertEquals("BOGUS", um.getDescription());
+        WeightQualifier wq = WeightQualifier.convert("BOGUS");
+        assertEquals(WeightQualifier.UNKNOWN, wq);
+        assertEquals("BOGUS", wq.getDescription());
     }
 
     @Test
     public void test_invalid_empty() {
-        UnitMeasure um = UnitMeasure.convert("");
-        assertEquals(UnitMeasure.UNKNOWN, um);
-        assertEquals("", um.getDescription());
+        WeightQualifier wq = WeightQualifier.convert("");
+        assertEquals(WeightQualifier.UNKNOWN, wq);
+        assertEquals("", wq.getDescription());
     }
 
     @Test

--- a/src/test/java/com/walmartlabs/x12/util/checksum/BarCodeMod10ChecksumTest.java
+++ b/src/test/java/com/walmartlabs/x12/util/checksum/BarCodeMod10ChecksumTest.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.checksum;
+package com.walmartlabs.x12.util.checksum;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/walmartlabs/x12/util/checksum/LuhnMod10ChecksumTest.java
+++ b/src/test/java/com/walmartlabs/x12/util/checksum/LuhnMod10ChecksumTest.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.checksum;
+package com.walmartlabs.x12.util.checksum;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/walmartlabs/x12/util/crc/DefaultCrc16Test.java
+++ b/src/test/java/com/walmartlabs/x12/util/crc/DefaultCrc16Test.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package com.walmartlabs.x12.crc;
+package com.walmartlabs.x12.util.crc;
 
 import com.walmartlabs.x12.dex.dx894.DefaultDex894Validator;
 import org.junit.Before;

--- a/src/test/java/sample/aaa/AaaTransactionSetParser.java
+++ b/src/test/java/sample/aaa/AaaTransactionSetParser.java
@@ -15,14 +15,14 @@ public class AaaTransactionSetParser extends AbstractTransactionSetParserChainab
     protected X12TransactionSet doParse(List<X12Segment> txLines, X12Group x12Group) {
         assertNotNull(txLines);
         assertEquals(3, txLines.size());
-        assertEquals("ST", txLines.get(0).getSegmentIdentifier());
-        assertEquals("AAA", txLines.get(0).getSegmentElement(1));
-        assertEquals("TEST", txLines.get(1).getSegmentIdentifier());
-        assertEquals("SE", txLines.get(2).getSegmentIdentifier());
+        assertEquals("ST", txLines.get(0).getIdentifier());
+        assertEquals("AAA", txLines.get(0).getElement(1));
+        assertEquals("TEST", txLines.get(1).getIdentifier());
+        assertEquals("SE", txLines.get(2).getIdentifier());
         
         TypeAaaTransactionSet tx = new TypeAaaTransactionSet();
-        tx.setTransactionSetIdentifierCode(txLines.get(0).getSegmentElement(1));
-        tx.setAaaOnlyValue(txLines.get(1).getSegmentElement(1));
+        tx.setTransactionSetIdentifierCode(txLines.get(0).getElement(1));
+        tx.setAaaOnlyValue(txLines.get(1).getElement(1));
         return tx;
     }
 
@@ -30,7 +30,7 @@ public class AaaTransactionSetParser extends AbstractTransactionSetParserChainab
         boolean isHandled = false;
         if (transactionSegments != null) {
             X12Segment segment = transactionSegments.get(0);
-            if (segment != null && "AAA".equals(segment.getSegmentElement(1))) {
+            if (segment != null && "AAA".equals(segment.getElement(1))) {
                 isHandled = true;
             }
         }

--- a/src/test/java/sample/bbb/BbbTransactionSetParser.java
+++ b/src/test/java/sample/bbb/BbbTransactionSetParser.java
@@ -15,14 +15,14 @@ public class BbbTransactionSetParser extends AbstractTransactionSetParserChainab
     protected X12TransactionSet doParse(List<X12Segment> txLines, X12Group x12Group) {
         assertNotNull(txLines);
         assertEquals(3, txLines.size());
-        assertEquals("ST", txLines.get(0).getSegmentIdentifier());
-        assertEquals("BBB", txLines.get(0).getSegmentElement(1));
-        assertEquals("TEST", txLines.get(1).getSegmentIdentifier());
-        assertEquals("SE", txLines.get(2).getSegmentIdentifier());
+        assertEquals("ST", txLines.get(0).getIdentifier());
+        assertEquals("BBB", txLines.get(0).getElement(1));
+        assertEquals("TEST", txLines.get(1).getIdentifier());
+        assertEquals("SE", txLines.get(2).getIdentifier());
         
         TypeBbbTransactionSet tx = new TypeBbbTransactionSet();
-        tx.setTransactionSetIdentifierCode(txLines.get(0).getSegmentElement(1));
-        tx.setValue(txLines.get(1).getSegmentElement(1));
+        tx.setTransactionSetIdentifierCode(txLines.get(0).getElement(1));
+        tx.setValue(txLines.get(1).getElement(1));
         return tx;
     }
 
@@ -30,7 +30,7 @@ public class BbbTransactionSetParser extends AbstractTransactionSetParserChainab
         boolean isHandled = false;
         if (transactionSegments != null) {
             X12Segment segment = transactionSegments.get(0);
-            if (segment != null && "BBB".equals(segment.getSegmentElement(1))) {
+            if (segment != null && "BBB".equals(segment.getElement(1))) {
                 isHandled = true;
             }
         }

--- a/src/test/java/sample/parser/SampleX12Parser.java
+++ b/src/test/java/sample/parser/SampleX12Parser.java
@@ -33,7 +33,7 @@ public class SampleX12Parser implements X12Parser<SampleX12Document> {
                 mockX12 = new SampleX12Document();
                 List<X12Segment> segments = this.splitSourceDataIntoSegments(sourceData);
                 if (!segments.isEmpty()) {
-                    mockX12.setFunctionalId(segments.get(0).getSegmentElement(1));
+                    mockX12.setFunctionalId(segments.get(0).getElement(1));
                 }
             }
         } catch (Exception e) {

--- a/src/test/java/sample/yyz/YyzTransactionSetParser.java
+++ b/src/test/java/sample/yyz/YyzTransactionSetParser.java
@@ -13,13 +13,13 @@ public class YyzTransactionSetParser implements TransactionSetParser {
     public X12TransactionSet parseTransactionSet(List<X12Segment> txLines, X12Group x12Group) {
         TypeYyzTransactionSet tx = null;
         if (txLines != null && !txLines.isEmpty()) {
-            String type = txLines.get(0).getSegmentElement(1);
+            String type = txLines.get(0).getElement(1);
             if ("YYZ".equals(type)) {
                 tx = new TypeYyzTransactionSet();
                 tx.setTransactionSetIdentifierCode(type);
                 X12Segment nextLine = txLines.get(1);
                 if (nextLine != null) {
-                    tx.setValue(nextLine.getSegmentElement(1));
+                    tx.setValue(nextLine.getElement(1));
                 }
             }
         }


### PR DESCRIPTION
Moved the types (UnitOfMeasure etc) out of DEX packages and into a shared package (types).
Updated these types to be more consistent across each other
- all methods to get enum from code are named `convert`
- all methods to get the "name" of the enum value are named `getDescription`
- when the enum is `UNKNOWN` the code is available via `getDescription`

Also moved arounds some classes in `util` package