### PR TITLE
X12Rule to check IEA and GE trailer counts

### DIFF
--- a/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
@@ -10,7 +10,7 @@ import com.walmartlabs.x12.util.ConversionUtil;
 
 import java.util.List;
 
-public class TrailerSegmentCountX12Rule {
+public class TrailerSegmentCountX12Rule implements X12Rule {
 
     /**
      * check each trailer record and verify 
@@ -19,6 +19,7 @@ public class TrailerSegmentCountX12Rule {
      * 
      * @param segmentList
      */
+    @Override
     public void verify(List<X12Segment> segmentList) {
         
         SegmentIterator segments = new SegmentIterator(segmentList);

--- a/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
@@ -1,0 +1,107 @@
+package com.walmartlabs.x12.rule;
+
+import com.walmartlabs.x12.SegmentIterator;
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.exceptions.X12ErrorDetail;
+import com.walmartlabs.x12.exceptions.X12ParserException;
+import com.walmartlabs.x12.standard.StandardX12Parser;
+import com.walmartlabs.x12.util.ConversionUtil;
+
+import java.util.List;
+
+public class TrailerSegmentCountX12Rule {
+
+    /**
+     * check each trailer record and verify 
+     * that the total segments match what 
+     * is reported in the trailer count
+     * 
+     * @param segmentList
+     */
+    public void verify(List<X12Segment> segmentList) {
+        
+        SegmentIterator segments = new SegmentIterator(segmentList);
+
+        int groupHeaders = 0;
+        int groupTrailers = 0;
+        int transactionCount = 0;
+        String currentGroupControlNumber = null;
+        int groupCountOnIeaTrailer = this.findGroupCountOnIeaTrailer(segmentList);
+        
+        while (segments.hasNext()) {
+            X12Segment currentSegment = segments.next();
+            
+            if (StandardX12Parser.GROUP_HEADER_ID.equals(currentSegment.getIdentifier())) {
+                groupHeaders++;
+                currentGroupControlNumber = currentSegment.getElement(6);
+            }
+            
+            if (X12TransactionSet.TRANSACTION_SET_HEADER.equals(currentSegment.getIdentifier())) {
+                transactionCount++;
+            }
+            
+            if (StandardX12Parser.GROUP_TRAILER_ID.equals(currentSegment.getIdentifier())) {
+                groupTrailers++;
+                this.verifyTransactionsOnGroupTrailer(currentGroupControlNumber, transactionCount, currentSegment);
+                
+                // reset transaction numbers
+                transactionCount = 0;
+                currentGroupControlNumber = null;
+            }
+        }
+        
+        this.verifyInterchangeControlTrailer(groupHeaders, groupTrailers, groupCountOnIeaTrailer);
+    }
+    
+    /**
+     * find IEA segment and get number of groups
+     */
+    private int findGroupCountOnIeaTrailer(List<X12Segment> segmentList) {
+        int groupCountOnIeaTrailer = 0;
+        int segmentCount = segmentList.size();
+        
+        X12Segment ieaTrailer = segmentList.get(segmentCount - 1);
+        if (StandardX12Parser.ISA_TRAILER_ID.equals(ieaTrailer.getIdentifier())) {
+            groupCountOnIeaTrailer = ConversionUtil.convertStringToInteger(ieaTrailer.getElement(1));
+        } else {
+            // error
+            throw new X12ParserException(
+                new X12ErrorDetail("IEA", "", "missing IEA segment"));
+        }
+        
+        return groupCountOnIeaTrailer;
+    }
+    
+    /**
+     * IEA02 should match the total number of groups
+     * that are in the EDI file
+     */
+    private void verifyInterchangeControlTrailer(int groupHeaders, int groupTrailers, int groupCountOnIeaTrailer) {
+        if (groupHeaders == groupTrailers && groupHeaders == groupCountOnIeaTrailer) {
+            // ok
+        } else {
+            // error
+            throw new X12ParserException(
+                new X12ErrorDetail("IEA", "IEA02", "incorrect number of groups on IEA trailer"));
+        }
+    }
+    
+    private void verifyTransactionsOnGroupTrailer(String currentGroupControlNumber, int transactionCount, X12Segment currentSegment) {
+        if (currentGroupControlNumber != null && currentGroupControlNumber.equals(currentSegment.getElement(2))) {
+            int transactionCountOnGroupTrailer = ConversionUtil.convertStringToInteger(currentSegment.getElement(1));
+            
+            if (transactionCountOnGroupTrailer == transactionCount) {
+                // ok
+            } else {
+                // error
+                throw new X12ParserException(
+                    new X12ErrorDetail("GE", "GE02", "incorrect number of transactions on group"));
+            }
+        } else {
+            // error
+            throw new X12ParserException(
+                new X12ErrorDetail("GE", "GE02", "groups seem to be misaligned"));
+        }
+    }
+}

--- a/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
+++ b/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
@@ -4,11 +4,16 @@ import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.exceptions.X12ParserException;
 import com.walmartlabs.x12.standard.StandardX12Parser;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
 public class TrailerSegmentCountX12RuleTest {
+    
+    @Rule 
+    public ExpectedException exception = ExpectedException.none();
     
     private TrailerSegmentCountX12Rule rule;
     
@@ -101,46 +106,8 @@ public class TrailerSegmentCountX12RuleTest {
         rule.verify(segmentList);
     }
     
-    @Test(expected = X12ParserException.class)
-    public void test_two_group_mismatch() {
-        String sourceData = new StringBuilder()
-            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
-            .append("\r\n")
-            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
-            .append("\r\n")
-            .append("ST*856*0001")
-            .append("\r\n")
-            .append("BSN*00*804190*20201022")
-            .append("\r\n")
-            .append("SE*1*0001")
-            .append("\r\n")
-            .append("ST*856*0002")
-            .append("\r\n")
-            .append("BSN*00*804191*20201022")
-            .append("\r\n")
-            .append("SE*1*0002")
-            .append("\r\n")            
-            .append("GE*2*100")
-            .append("\r\n")
-            .append("GS*SH*4405197800*999999999*20111206*1045*100*X*004060")
-            .append("\r\n")
-            .append("ST*850*0003")
-            .append("\r\n")
-            .append("BEG*00*SA*804191**20201022")
-            .append("\r\n")
-            .append("SE*1*0003")
-            .append("\r\n")            
-            .append("GE*1*99")
-            .append("\r\n")
-            .append("IEA*2*000000049")
-            .toString();
-
-        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
-        rule.verify(segmentList);
-    }
-    
-    @Test(expected = X12ParserException.class)
-    public void test_one_group_incorrect() {
+    @Test
+    public void test_one_group_missing_group_count() {
         String sourceData = new StringBuilder()
             .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
             .append("\r\n")
@@ -166,9 +133,360 @@ public class TrailerSegmentCountX12RuleTest {
             .append("\r\n")            
             .append("GE*3*99")
             .append("\r\n")
+            // IEA missing group count
+            .append("IEA**000000049")
+            .toString();
+        
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("incorrect number of groups on IEA trailer");
+
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_one_group_alpha_group_count() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*3*99")
+            .append("\r\n")
+            // IEA says it expects A groups
+            .append("IEA*A*000000049")
+            .toString();
+        
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("Invalid numeric value");
+
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_two_group_mismatch_control_numbers() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01")
+            .append("\r\n")
+            // Group 99
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            // end for Group 100 (should be 99)
+            .append("GE*2*100")
+            .append("\r\n")
+            // Group 100
+            .append("GS*SH*4405197800*999999999*20111206*1045*100*X*004060")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")
+            // end for Group 99 (should be 100)
+            .append("GE*1*99")
+            .append("\r\n")
+            .append("IEA*2*000000049")
+            .toString();
+        
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("groups seem to be misaligned");
+
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_one_group_incorrect_group_count() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*3*99")
+            .append("\r\n")
+            // IEA says it expects 10 groups
+            // but only have 1 group
             .append("IEA*10*000000049")
             .toString();
 
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("incorrect number of groups on IEA trailer");
+        
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_one_group_missing_isa() {
+        String sourceData = new StringBuilder()
+            // because ISA is missing
+            // the segment delimiter can't be determined
+            // that causes an error in parsing the IEA segment
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*3*99")
+            .append("\r\n")
+            .append("IEA*1*000000049")
+            .toString();
+
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("missing IEA segment");
+        
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_one_group_missing_iea() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*3*99")
+            .append("\r\n")
+            .toString();
+
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("missing IEA segment");
+        
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_one_group_missing_gs() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ")
+            .append("\r\n")
+            // should be a GS
+            .append("XX*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*3*99")
+            .append("\r\n")
+            .append("IEA*1*000000049")
+            .toString();
+
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("groups seem to be misaligned");
+        
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_one_group_missing_ge() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")
+            // no GE 
+            .append("IEA*1*000000049")
+            .toString();
+
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("incorrect number of groups on IEA trailer");
+        
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+
+    @Test
+    public void test_one_group_alpha_transaction_count() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")  
+            // transaction count is A instead of number
+            .append("GE*A*99")
+            .append("\r\n")
+            .append("IEA*1*000000049")
+            .toString();
+
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("Invalid numeric value");
+        
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_one_group_missing_transaction_count() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")  
+            // transaction count is missing
+            .append("GE**99")
+            .append("\r\n")
+            .append("IEA*1*000000049")
+            .toString();
+
+        exception.expect(X12ParserException.class);
+        exception.expectMessage("incorrect number of transactions on group");
+        
         List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
         rule.verify(segmentList);
     }

--- a/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
+++ b/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
@@ -1,0 +1,176 @@
+package com.walmartlabs.x12.rule;
+
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.exceptions.X12ParserException;
+import com.walmartlabs.x12.standard.StandardX12Parser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TrailerSegmentCountX12RuleTest {
+    
+    private TrailerSegmentCountX12Rule rule;
+    
+    @Before
+    public void init() {
+        rule = new TrailerSegmentCountX12Rule();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_verify_null() {
+        List<X12Segment> segmentList = null;
+        rule.verify(segmentList);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void test_verify_empty() {
+        List<X12Segment> segmentList = null;
+        rule.verify(segmentList);
+    }
+
+    @Test
+    public void test_one_group_correct() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*3*99")
+            .append("\r\n")
+            .append("IEA*1*000000049")
+            .toString();
+
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test
+    public void test_two_group_correct() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")            
+            .append("GE*2*99")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*100*X*004060")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*1*100")
+            .append("\r\n")
+            .append("IEA*2*000000049")
+            .toString();
+
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test(expected = X12ParserException.class)
+    public void test_two_group_mismatch() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")            
+            .append("GE*2*100")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*100*X*004060")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*1*99")
+            .append("\r\n")
+            .append("IEA*2*000000049")
+            .toString();
+
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+    
+    @Test(expected = X12ParserException.class)
+    public void test_one_group_incorrect() {
+        String sourceData = new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABCDEFGHIJKLMNO*ZZ*123456789012345*101127*1719*U*00400*000000049*0*P*>")
+            .append("\r\n")
+            .append("GS*SH*4405197800*999999999*20111206*1045*99*X*004060")
+            .append("\r\n")
+            .append("ST*856*0001")
+            .append("\r\n")
+            .append("BSN*00*804190*20201022")
+            .append("\r\n")
+            .append("SE*1*0001")
+            .append("\r\n")
+            .append("ST*856*0002")
+            .append("\r\n")
+            .append("BSN*00*804191*20201022")
+            .append("\r\n")
+            .append("SE*1*0002")
+            .append("\r\n")
+            .append("ST*850*0003")
+            .append("\r\n")
+            .append("BEG*00*SA*804191**20201022")
+            .append("\r\n")
+            .append("SE*1*0003")
+            .append("\r\n")            
+            .append("GE*3*99")
+            .append("\r\n")
+            .append("IEA*10*000000049")
+            .toString();
+
+        List<X12Segment> segmentList = new StandardX12Parser().splitSourceDataIntoSegments(sourceData.trim());
+        rule.verify(segmentList);
+    }
+
+}


### PR DESCRIPTION
The X12Rule is designed to be generic and reusable
The current idea is to be able to wire a rule set into the EDI splitter to allow a consumer to verify some basic values in the entire message that would be harder to do after splitting
```
splitter.registerX12Rule(new UniqueDocumentX12Rule(“BSN”, 2, 3));
splitter.registerX12Rule(new UniqueDocumentX12Rule(“BEG”, 3, 4));
splitter.registerX12Rule(new UniqueDocumentX12Rule(“YYZ”, 33 93));
splitter.registerX12Rule(new TrailerSegmentCountX12Rule());
```
These rules would be chained in the splitter and be run one after the other