### PR TITLE
Add the X12Rule interface

### DIFF
--- a/src/main/java/com/walmartlabs/x12/rule/X12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/X12Rule.java
@@ -1,0 +1,11 @@
+package com.walmartlabs.x12.rule;
+
+import com.walmartlabs.x12.X12Segment;
+
+import java.util.List;
+
+public interface X12Rule {
+
+    void verify(List<X12Segment> segmentList);
+
+}


### PR DESCRIPTION
The X12Rule is designed to be generic and reusable
The current idea is to be able to wire a rule set into the EDI splitter to allow a consumer to verify some basic values in the entire message that would be harder to do after splitting