### PR TITLE
Utility to run directory of files thru parser

### DIFF
--- a/src/itest/java/Asn856BatchFileParser.java
+++ b/src/itest/java/Asn856BatchFileParser.java
@@ -1,0 +1,125 @@
+import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.asn856.AsnTransactionSet;
+import com.walmartlabs.x12.asn856.DefaultAsn856TransactionSetParser;
+import com.walmartlabs.x12.asn856.Shipment;
+import com.walmartlabs.x12.common.segment.N1PartyIdentification;
+import com.walmartlabs.x12.standard.StandardX12Document;
+import com.walmartlabs.x12.standard.X12Group;
+import com.walmartlabs.x12.standard.X12Loop;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Asn856BatchFileParser extends BatchFileParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Asn856BatchFileParser.class);
+    
+    private Path targetFile;
+    
+    
+    protected static BatchFileParser createBatchFileParser() {
+        return new Asn856BatchFileParser();
+    }
+    
+    @Override
+    protected void registerTransactionSetParsers() {
+        x12Parser.registerTransactionSetParser(new DefaultAsn856TransactionSetParser());
+    }
+    
+    @Override
+    protected void checkDocument(StandardX12Document x12Doc, Path sourceFileName, Path okFolder) {
+        this.createCheckDocumentFile(sourceFileName, okFolder);
+        this.examineDocument(x12Doc);
+    }
+    
+    private void createCheckDocumentFile(Path sourceFileName, Path okFolder) {
+        // set the name of the file
+        this.targetFile = okFolder.resolve(sourceFileName + ".transactions.txt");
+        
+        // open it for writing
+        try {
+            Files.write(targetFile, "".getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            
+        } catch (Exception e) {
+           LOGGER.error(e.getMessage(), e);
+        }
+        
+    }
+    
+    private void writeTransactionToFile(StringBuilder sb) {
+        try {
+            
+            Files.write(targetFile, sb.toString().getBytes(), StandardOpenOption.APPEND);
+            
+        } catch (Exception e) {
+           LOGGER.error(e.getMessage(), e);
+        }        
+    }
+    
+    private void examineDocument(StandardX12Document x12Doc) {
+        List<X12Group> groups = x12Doc.getGroups();
+        if (!CollectionUtils.isEmpty(groups)) {
+            groups.forEach(this::checkGroup);
+        }
+    }
+    
+    private void checkGroup(X12Group group) {
+        List<X12TransactionSet> transactions = group.getTransactions();
+        if (!CollectionUtils.isEmpty(transactions)) {
+            transactions.forEach(this::checkTransaction);
+        }
+    }
+    
+    private void checkTransaction(X12TransactionSet transaction) {
+        if ("856".equals(transaction.getTransactionSetIdentifierCode())) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Transaction: 856");
+            sb.append("\r\n");
+            
+            AsnTransactionSet asnTx = (AsnTransactionSet) transaction;
+            
+            sb.append("Document Number (BSN02):");
+            sb.append(asnTx.getShipmentIdentification());
+            sb.append("\r\n");
+            
+            sb.append("Document Date (BSN03):");
+            sb.append(asnTx.getShipmentDate());
+            sb.append("\r\n");
+                
+            LOGGER.info(sb.toString());
+                
+            Shipment shipment = asnTx.getShipment();
+            List<N1PartyIdentification> n1List = shipment.getN1PartyIdenfications();
+            if (!CollectionUtils.isEmpty(n1List)) {
+                
+                List<N1PartyIdentification> stList = n1List.stream()
+                    .filter(n1 -> "ST".equals(n1.getEntityIdentifierCode()))
+                    .collect(Collectors.toList());
+                
+                if (!CollectionUtils.isEmpty(stList)) {
+                    N1PartyIdentification n1ShipTo= stList.get(0);
+                    sb.append("ST: (N103 - N104):");
+                    sb.append(n1ShipTo.getIdentificationCodeQualifier());
+                    sb.append("-");
+                    sb.append(n1ShipTo.getIdentificationCode());
+                    sb.append("\r\n");
+                } else {
+                    sb.append("ST: (N103 - N104): missing");
+                }
+
+            }
+
+            List<X12Loop> shipmentChildLoops = shipment.getParsedChildrenLoops();
+                
+            this.writeTransactionToFile(sb);
+            
+        }
+            
+    }
+}

--- a/src/itest/java/BatchFileParser.java
+++ b/src/itest/java/BatchFileParser.java
@@ -1,4 +1,5 @@
 import com.walmartlabs.x12.exceptions.X12ParserException;
+import com.walmartlabs.x12.standard.StandardX12Document;
 import com.walmartlabs.x12.standard.StandardX12Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +19,8 @@ import java.util.stream.Stream;
 
 public class BatchFileParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchFileParser.class);
-    private static final StandardX12Parser x12Parser = new StandardX12Parser();
+    
+    protected static final StandardX12Parser x12Parser = new StandardX12Parser();
     
     private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
     private static final Charset LATIN_ONE_CHARSET = StandardCharsets.ISO_8859_1;
@@ -31,12 +33,9 @@ public class BatchFileParser {
             Path inputFolder = Paths.get(inputDirectory);
 
             if (Files.exists(inputFolder)) {
-                Path okFolder = Paths.get(inputDirectory + "/success");
-                createFolderIfNotExists(okFolder);
-                Path rejectFolder = Paths.get(inputDirectory + "/failed");
-                createFolderIfNotExists(rejectFolder);
-                
-                processDirectory(inputFolder, okFolder, rejectFolder);
+                BatchFileParser bfp = createBatchFileParser();
+                bfp.registerTransactionSetParsers();
+                bfp.runBatch(inputDirectory);
             } else {
                 LOGGER.warn("the input folder does not exist");
             }
@@ -44,8 +43,19 @@ public class BatchFileParser {
             LOGGER.warn("please provide an input folder as an argument");
         }
     }
+    
+    private void runBatch(String inputDirectory) throws IOException {
+        Path inputFolder = Paths.get(inputDirectory);
         
-    private static void processDirectory(Path inputFolder, Path okFolder, Path rejectFolder) throws IOException {
+        Path okFolder = Paths.get(inputDirectory + "/success");
+        this.createFolderIfNotExists(okFolder);
+        Path rejectFolder = Paths.get(inputDirectory + "/failed");
+        this.createFolderIfNotExists(rejectFolder);
+        
+        processDirectory(inputFolder, okFolder, rejectFolder);
+    }
+    
+    private void processDirectory(Path inputFolder, Path okFolder, Path rejectFolder) throws IOException {
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failedCount = new AtomicInteger(0);
         
@@ -64,16 +74,21 @@ public class BatchFileParser {
         LOGGER.info("Parsed files - successful {}, failed {}", successCount, failedCount);
     }
 
-    private static boolean parseFile(Path sourceFile, Path okFolder, Path rejectFolder) {
+    private boolean parseFile(Path sourceFile, Path okFolder, Path rejectFolder) {
         boolean isSuccess = false;
         
         try {
+            LOGGER.info("parsing file {}", sourceFile.getFileName());
+            
             // read the file
             String sourceData = readFile(sourceFile);
             
             // parse the file
-            x12Parser.parse(sourceData);
-
+            StandardX12Document x12Doc = x12Parser.parse(sourceData);
+            
+            // check the document
+            this.checkDocument(x12Doc, sourceFile.getFileName(),  okFolder);
+            
             // copy the file to OK folder
             copyFile(sourceFile, okFolder);
             isSuccess = true;
@@ -88,8 +103,8 @@ public class BatchFileParser {
         
         return isSuccess;
     }
-
-    private static String readFile(Path sourceFile) throws IOException {
+    
+    private String readFile(Path sourceFile) throws IOException {
         String fileContents = null;
         try {
             fileContents = readFile(sourceFile, UTF8_CHARSET);
@@ -105,7 +120,7 @@ public class BatchFileParser {
         return fileContents;
     }
     
-    private static String readFile(Path sourceFile, Charset charSet) throws IOException {
+    private String readFile(Path sourceFile, Charset charSet) throws IOException {
         // read the file
         String content = null;
         try (Stream<String> lines = Files.lines(sourceFile, charSet)) {
@@ -114,7 +129,7 @@ public class BatchFileParser {
         return content;
     }
     
-    private static void writeReasonFile(Path sourceFile, Path rejectFolder, String errReason) {
+    private void writeReasonFile(Path sourceFile, Path rejectFolder, String errReason) {
         try {
             Path errFile = rejectFolder.resolve(sourceFile.getFileName() + ".reason.txt");
             Files.write(errFile, errReason.getBytes());
@@ -123,7 +138,7 @@ public class BatchFileParser {
          }
     }
     
-    private static void copyFile(Path fileToCopy, Path folder) {
+    private void copyFile(Path fileToCopy, Path folder) {
         try {
             Path targetFile = folder.resolve(fileToCopy.getFileName());
             Files.copy(fileToCopy, targetFile, StandardCopyOption.REPLACE_EXISTING);
@@ -132,10 +147,35 @@ public class BatchFileParser {
         }
     }
     
-    private static void createFolderIfNotExists(Path folder) throws IOException {
+    private void createFolderIfNotExists(Path folder) throws IOException {
         if (!Files.exists(folder)) {
             Files.createDirectories(folder);
         }
+    }
+    
+    /**
+     * hack for the moment
+     * can hide this in a subclass to create a different BFP
+     */
+    protected static BatchFileParser createBatchFileParser() {
+        return new BatchFileParser();
+    }
+    
+    /**
+     * override this method 
+     * and register parsers
+     */
+    protected void registerTransactionSetParsers() {
+    }
+    
+    /**
+     * override this method 
+     * check the results of parsing the document 
+     * and write some meta data to a file
+     * @param x12Doc
+     * @throws X12ParserException to indicate an error in the document
+     */
+    protected void checkDocument(StandardX12Document x12Doc, Path sourceFileName, Path okFolder) {
     }
 
 }

--- a/src/itest/java/logback.xml
+++ b/src/itest/java/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
This utility can be used to quickly process a directory of EDI files to evaluate how the parser is handling them

The directory is specified as a command line parameter

It will run thru each file 
- all successfully parsed files will be placed in the success folder
- all files that fail will be placed in the failed folder
- unexpected issues will be placed in the wat folder