### PR TITLE
Allow DTM segments between BSN and HL

### DIFF
--- a/src/main/java/com/walmartlabs/x12/SegmentIterator.java
+++ b/src/main/java/com/walmartlabs/x12/SegmentIterator.java
@@ -114,5 +114,12 @@ public class SegmentIterator implements ListIterator<X12Segment> {
     public void set(X12Segment segment) {
         throw new UnsupportedOperationException();
     }
+    
+    /**
+     * non-standard iterator method to return the current index
+     */
+    public int currentIndex() {
+        return currentSegmentIdx;
+    }
 
 }

--- a/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
+++ b/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
@@ -200,8 +200,8 @@ public final class X12ParsingUtil {
      * @param segment
      * @return true if HL otherwise false
      */
-    private static boolean isHierarchalLoopStart(X12Segment segment) {
-        return segment != null && "HL".equals(segment.getIdentifier());
+    public static boolean isHierarchalLoopStart(X12Segment segment) {
+        return segment != null && X12Loop.HIERARCHY_LOOP_ID.equals(segment.getIdentifier());
     }
     
     private static X12Loop buildHierarchalLoop(X12Segment x12Segment) {

--- a/src/main/java/com/walmartlabs/x12/asn856/AsnTransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/AsnTransactionSet.java
@@ -17,6 +17,11 @@ limitations under the License.
 package com.walmartlabs.x12.asn856;
 
 import com.walmartlabs.x12.AbstractX12TransactionSet;
+import com.walmartlabs.x12.common.segment.DTMDateTimeReference;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AsnTransactionSet extends AbstractX12TransactionSet {
 
@@ -34,8 +39,12 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
     // BSN 05
     private String hierarchicalStructureCode;
     
+    // DTM segments (can appear between BSN and HL*S
+    private List<DTMDateTimeReference> dtmReferences;
+    
     // HL (Shipment)
-    Shipment shipment;
+    // the first loop in the HL hierarchy
+    private Shipment shipment;
     
     //
     // CTT
@@ -44,6 +53,17 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
     private Integer transactionLineItems;
 
     
+    
+    /**
+     * helper method to add DTM to list
+     * @param dtm
+     */
+    public void addDTMDateTimeReference(DTMDateTimeReference dtm) {
+        if (CollectionUtils.isEmpty(dtmReferences)) {
+            dtmReferences = new ArrayList<>();
+        }
+        dtmReferences.add(dtm);
+    }
     
     public String getPurposeCode() {
         return purposeCode;
@@ -99,6 +119,14 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
 
     public void setTransactionLineItems(Integer transactionLineItems) {
         this.transactionLineItems = transactionLineItems;
+    }
+
+    public List<DTMDateTimeReference> getDtmReferences() {
+        return dtmReferences;
+    }
+
+    public void setDtmReferences(List<DTMDateTimeReference> dtmReferences) {
+        this.dtmReferences = dtmReferences;
     }
     
 }

--- a/src/main/java/com/walmartlabs/x12/standard/StandardX12Parser.java
+++ b/src/main/java/com/walmartlabs/x12/standard/StandardX12Parser.java
@@ -63,7 +63,7 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
 
     public static final String GROUP_HEADER_ID = "GS";
     public static final String GROUP_TRAILER_ID = "GE";
-
+    
     private TransactionSetParser transactionParser;
     private UnhandledTransactionSet unhandledTransactionSet;
 
@@ -229,14 +229,14 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
                     } else {
                         // we are not in a transaction
                         // so should not have gotten transaction trailer
-                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_HEADER, currentSegment.getIdentifier());
+                        this.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_HEADER, currentSegment.getIdentifier());
                     }
                 } else if (GROUP_TRAILER_ID.equals(currentSegment.getIdentifier())) {
                     if (insideTransaction) {
                         // we are already in a transaction
                         // and have not encountered the end
                         // so we will stop parsing
-                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
+                        this.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
                     } else {
                         insideGroup = false;
                     }
@@ -249,13 +249,13 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
             // if we got here we should have cleanly
             // exited a transaction
             if (insideTransaction) {
-                handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
+                this.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
             }
 
             // if we got here we should have cleanly
             // exited a group
             if (insideGroup) {
-                handleUnexpectedSegment(GROUP_TRAILER_ID, currentSegment.getIdentifier());
+                this.handleUnexpectedSegment(GROUP_TRAILER_ID, currentSegment.getIdentifier());
             }
 
             // parse group trailer

--- a/src/main/java/com/walmartlabs/x12/standard/X12Loop.java
+++ b/src/main/java/com/walmartlabs/x12/standard/X12Loop.java
@@ -27,7 +27,9 @@ import java.util.Optional;
  * models a basic HL loop with support for nesting
  */
 public class X12Loop {
-
+    
+    public static final String HIERARCHY_LOOP_ID = "HL";
+    
     /*
      * HL
      */

--- a/src/main/java/com/walmartlabs/x12/standard/txset/AbstractTransactionSetParserChainable.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/AbstractTransactionSetParserChainable.java
@@ -19,6 +19,7 @@ package com.walmartlabs.x12.standard.txset;
 import com.walmartlabs.x12.X12ParsingUtil;
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.exceptions.X12ParserException;
 import com.walmartlabs.x12.standard.X12Group;
 import com.walmartlabs.x12.util.ConversionUtil;
 import org.slf4j.Logger;
@@ -106,6 +107,7 @@ public abstract class AbstractTransactionSetParserChainable implements Transacti
      * parse the ST segment (reusable from concrete class)
      * @param segment
      * @param transactionSet
+     * @throws X12ParserException if segment is not ST (unexpected)
      */
     protected void parseTransactionSetHeader(X12Segment segment, X12TransactionSet transactionSet) {
         LOGGER.debug(segment.getIdentifier());
@@ -123,6 +125,7 @@ public abstract class AbstractTransactionSetParserChainable implements Transacti
      * parse the SE segment (reusable from concrete class)
      * @param segment
      * @param transactionSet
+     * @throws X12ParserException if segment is not SE
      */
     protected void parseTransactionSetTrailer(X12Segment segment, X12TransactionSet transactionSet) {
         LOGGER.debug(segment.getIdentifier());

--- a/src/main/java/com/walmartlabs/x12/standard/txset/TransactionSetParser.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/TransactionSetParser.java
@@ -29,6 +29,9 @@ public interface TransactionSetParser {
      * implementation should NOT add the transaction set to the group
      * the group is available to give the transaction context if needed
      * 
+     * it can expect the list of transactionSegments to have the first segment have an id of ST
+     * and the last segment have an id of SE
+     * 
      * @param transactionSegments
      * @param x12Group
      * @return the parsed transaction set


### PR DESCRIPTION
Fixes #107 
Allows one or more DTM segments to appear between the BSN and HL in an ASN transaction set