### PR TITLE
add Generic TxSet Parser and POJO

### DIFF
--- a/src/main/java/com/walmartlabs/x12/AbstractX12TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/AbstractX12TransactionSet.java
@@ -20,7 +20,7 @@ package com.walmartlabs.x12;
  * 
  * the {@link AbstractX12TransactionSet} is not required when creating a 
  * custom {@link X12TransactionSet}. It is provided as a convenience to handle 
- * common ST/SE elements. 
+ * common ST/SE elements and the CTT segment. 
  *
  */
 public abstract class AbstractX12TransactionSet implements X12TransactionSet {
@@ -33,6 +33,12 @@ public abstract class AbstractX12TransactionSet implements X12TransactionSet {
     private String headerControlNumber;
 
     /*
+     * CTT (optional)
+     */
+    // CTT 01
+    private Integer transactionLineItems;
+    
+    /*
      * SE
      */
     // SE01
@@ -40,7 +46,7 @@ public abstract class AbstractX12TransactionSet implements X12TransactionSet {
     // SE02
     private String trailerControlNumber;
     
-    
+
     public String getTransactionSetIdentifierCode() {
         return transactionSetIdentifierCode;
     }
@@ -71,6 +77,14 @@ public abstract class AbstractX12TransactionSet implements X12TransactionSet {
 
     public void setTrailerControlNumber(String trailerControlNumber) {
         this.trailerControlNumber = trailerControlNumber;
+    }
+    
+    public Integer getTransactionLineItems() {
+        return transactionLineItems;
+    }
+
+    public void setTransactionLineItems(Integer transactionLineItems) {
+        this.transactionLineItems = transactionLineItems;
     }
 
 }

--- a/src/main/java/com/walmartlabs/x12/SegmentIterator.java
+++ b/src/main/java/com/walmartlabs/x12/SegmentIterator.java
@@ -116,10 +116,28 @@ public class SegmentIterator implements ListIterator<X12Segment> {
     }
     
     /**
-     * non-standard iterator method to return the current index
+     * non-standard iterator method 
+     * returns the current index
      */
     public int currentIndex() {
         return currentSegmentIdx;
     }
+    
+    /**
+     * non-standard iterator method 
+     * resets the cursor position to the specified index
+     */
+    public void reset(int index) {
+        currentSegmentIdx = index;
+    }
+    
+    /**
+     * non-standard iterator method 
+     * return a subset of segments from the backing list
+     */
+    public List<X12Segment> subList(int fromIndex, int toIndex) {
+        return segmentLines.subList(fromIndex, toIndex);
+    }
+
 
 }

--- a/src/main/java/com/walmartlabs/x12/X12TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/X12TransactionSet.java
@@ -27,6 +27,8 @@ public interface X12TransactionSet {
     
     public static final String TRANSACTION_SET_HEADER = "ST";
     public static final String TRANSACTION_SET_TRAILER = "SE";
+    public static final String TRANSACTION_ITEM_TOTAL = "CTT";
+    public static final String TRANSACTION_AMOUNT_TOTAL = "AMT";
     
     /**
      * The ST01 segment element contains the functional group code, which 
@@ -70,4 +72,14 @@ public interface X12TransactionSet {
     String getTrailerControlNumber();
     
     void setTrailerControlNumber(String trailerControlNumber);
+    
+    /**
+     * The CTT01 segment element contains the transaction count. 
+     * This is an optional segment lien
+     * 
+     * @return the CTT01 segment value 
+     */
+    Integer getTransactionLineItems();
+
+    void setTransactionLineItems(Integer transactionLineItems);
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/AsnTransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/AsnTransactionSet.java
@@ -46,13 +46,6 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
     // the first loop in the HL hierarchy
     private Shipment shipment;
     
-    //
-    // CTT
-    //
-    // CTT 01
-    private Integer transactionLineItems;
-
-    
     
     /**
      * helper method to add DTM to list
@@ -111,14 +104,6 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
 
     public void setShipment(Shipment shipment) {
         this.shipment = shipment;
-    }
-
-    public Integer getTransactionLineItems() {
-        return transactionLineItems;
-    }
-
-    public void setTransactionLineItems(Integer transactionLineItems) {
-        this.transactionLineItems = transactionLineItems;
     }
 
     public List<DTMDateTimeReference> getDtmReferences() {

--- a/src/main/java/com/walmartlabs/x12/standard/txset/AbstractTransactionSetParserChainable.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/AbstractTransactionSetParserChainable.java
@@ -93,7 +93,6 @@ public abstract class AbstractTransactionSetParserChainable implements Transacti
      */
     protected abstract boolean handlesTransactionSet(List<X12Segment> transactionSegments, X12Group x12Group);
 
-    
     /**
      * parse the transaction set 
      * 
@@ -136,6 +135,23 @@ public abstract class AbstractTransactionSetParserChainable implements Transacti
             transactionSet.setTrailerControlNumber(segment.getElement(2));
         } else {
             throw X12ParsingUtil.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, segmentIdentifier);
+        }
+    }
+    
+    /**
+     * parse the CTT segment
+     * 
+     * @param segment
+     * @param asnTx
+     */
+    protected void parseTransactionTotals(X12Segment segment, X12TransactionSet asnTx) {
+        LOGGER.debug(segment.getIdentifier());
+
+        String segmentIdentifier = segment.getIdentifier();
+        if (X12TransactionSet.TRANSACTION_ITEM_TOTAL.equals(segmentIdentifier)) {
+            asnTx.setTransactionLineItems(ConversionUtil.convertStringToInteger(segment.getElement(1)));
+        } else {
+            throw X12ParsingUtil.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_ITEM_TOTAL, segmentIdentifier);
         }
     }
 }

--- a/src/main/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSet.java
@@ -1,0 +1,99 @@
+package com.walmartlabs.x12.standard.txset.generic;
+
+import com.walmartlabs.x12.AbstractX12TransactionSet;
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.standard.X12Loop;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** 
+ * 
+ * this transaction set implementation is a very generic
+ * class that will allow parsing of the basic X12 structures
+ * such as X12Segment and X12Loop. These structures will not
+ * be parsed beyond this.
+ * 
+ * It is the intention of this framework to have a specific
+ * transaction set class and parser to support more specific
+ * parsing of the transaction set 
+ * 
+ * This class can serve as a basic reference.
+ * 
+ * Sample: 
+ * 
+ * ST*YYZ*0001 <---- transaction header
+ * 
+ * YYZ*00*1234 <---- beginningSegment 
+ * DTM*000*20210408 <---- segments after beginning
+ * REF*ZZ*2112
+ * 
+ * HL*1**A     <----- first HL loop
+ * REF*XX*1234
+ * 
+ * HL*2*1*B    <----- child to first loop
+ * REF*XX*4321
+ * 
+ * CTT*10      <---- transaction totals
+ * SE*10*0001  <---- transaction trailer
+ *
+ */
+public class GenericTransactionSet extends AbstractX12TransactionSet {
+
+    private X12Segment beginningSegment;
+   
+    // all segments that appear after the beginning segment
+    // and before the first HL loop (if any)
+    private List<X12Segment> segmentsBeforeLoops;
+    
+    // the loops
+    private List<X12Loop> loops;
+   
+    /**
+     * helper method to add segment to list
+     * @param segment
+     */
+    public void addX12Segment(X12Segment segment) {
+        if (CollectionUtils.isEmpty(segmentsBeforeLoops)) {
+            segmentsBeforeLoops = new ArrayList<>();
+        }
+        segmentsBeforeLoops.add(segment);
+    }
+    
+    /**
+     * helper method to add loop to list
+     * @param loop
+     */
+    public void addX12Loop(X12Loop loop) {
+        if (CollectionUtils.isEmpty(loops)) {
+            loops = new ArrayList<>();
+        }
+        loops.add(loop);
+    }
+    
+    public X12Segment getBeginningSegment() {
+        return beginningSegment;
+    }
+
+    public void setBeginningSegment(X12Segment mainSegment) {
+        this.beginningSegment = mainSegment;
+    }
+    
+    public List<X12Segment> getSegmentsBeforeLoops() {
+        return segmentsBeforeLoops;
+    }
+
+    public void setSegmentsBeforeLoops(List<X12Segment> segmentsBeforeLoops) {
+        this.segmentsBeforeLoops = segmentsBeforeLoops;
+    }
+    
+    public List<X12Loop> getLoops() {
+        return loops;
+    }
+    
+    public void setLoops(List<X12Loop> loops) {
+        this.loops = loops;
+    }
+    
+}

--- a/src/main/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParser.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParser.java
@@ -75,7 +75,7 @@ public class GenericTransactionSetParser extends AbstractTransactionSetParserCha
         //
         if (segments.hasNext()) {
             currentSegment = segments.next();
-            if (this.isEndOfSegmentsBeforeLoops(currentSegment)) {
+            if (this.isLoopSegmentOrOptionalSegmentOrEndingSegment(currentSegment)) {
                 // unexpected segment HL, CTT, AMT or SE
                 throw X12ParsingUtil.handleUnexpectedSegment("Beginning", currentSegment.getIdentifier());
             } else {
@@ -127,7 +127,7 @@ public class GenericTransactionSetParser extends AbstractTransactionSetParserCha
         
         while (segments.hasNext()) {
             X12Segment currentSegment = segments.next();
-            if (this.isEndOfSegmentsBeforeLoops(currentSegment)) {
+            if (this.isLoopSegmentOrOptionalSegmentOrEndingSegment(currentSegment)) {
                 // we should back up so
                 // the parser starts w/ this segment
                 segments.previous();
@@ -144,7 +144,7 @@ public class GenericTransactionSetParser extends AbstractTransactionSetParserCha
      * checks for an HL loop, CTT or AMT or SE
      * @return
      */
-    private boolean isEndOfSegmentsBeforeLoops(X12Segment segment) {
+    private boolean isLoopSegmentOrOptionalSegmentOrEndingSegment(X12Segment segment) {
         return X12ParsingUtil.isHierarchalLoopStart(segment) 
             || X12TransactionSet.TRANSACTION_ITEM_TOTAL.equals(segment.getIdentifier())
             || X12TransactionSet.TRANSACTION_AMOUNT_TOTAL.equals(segment.getIdentifier())

--- a/src/main/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParser.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParser.java
@@ -1,0 +1,237 @@
+package com.walmartlabs.x12.standard.txset.generic;
+
+import com.walmartlabs.x12.SegmentIterator;
+import com.walmartlabs.x12.X12ParsingUtil;
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.exceptions.X12ParserException;
+import com.walmartlabs.x12.standard.X12Group;
+import com.walmartlabs.x12.standard.X12Loop;
+import com.walmartlabs.x12.standard.txset.AbstractTransactionSetParserChainable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+
+/**
+ * this transaction set parser implementation will parse 
+ * any transaction set into a {@link GenericTransactionSet} 
+ * which will hold the basic X12 structures
+ * like the {@link X12Segment} and the {@link X12Loop}
+ * 
+ * it will NOT be able to parse these basic X12 parts
+ * into more specific object types. for that a specific
+ * parser for a particular transaction set is required
+ *
+ * This class can serve as a basic reference.
+ */
+public class GenericTransactionSetParser extends AbstractTransactionSetParserChainable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenericTransactionSetParser.class);
+
+    /**
+     * generic parser will handle any transaction set
+     */
+    @Override
+    protected boolean handlesTransactionSet(List<X12Segment> transactionSegments, X12Group x12Group) {
+        return true;
+    }
+
+    /**
+     * it is assumed that this method is only called after getting true as a
+     * response from {@link handlesTransactionSet}
+     */
+    @Override
+    protected X12TransactionSet doParse(List<X12Segment> transactionSegments, X12Group x12Group) {
+        GenericTransactionSet genericTxSet = null;
+
+        if (!CollectionUtils.isEmpty(transactionSegments)) {
+            genericTxSet = new GenericTransactionSet();
+            this.doParsing(transactionSegments, genericTxSet);
+        }
+
+        return genericTxSet;
+    }
+    
+    /**
+     * the first segment in the list of {@link X12Segment} should be an ST
+     * the last segment in the list of {@link X12Segment} should be an SE
+     */
+    protected void doParsing(List<X12Segment> transactionSegments, GenericTransactionSet genericTx) {
+        SegmentIterator segments = new SegmentIterator(transactionSegments);
+        X12Segment currentSegment = null;
+
+        //
+        // ST
+        //
+        if (segments.hasNext()) {
+            currentSegment = segments.next();
+            this.parseTransactionSetHeader(currentSegment, genericTx);
+        }
+
+        //
+        // Beginning Segment line for the Transaction Set
+        //
+        if (segments.hasNext()) {
+            currentSegment = segments.next();
+            if (this.isEndOfSegmentsBeforeLoops(currentSegment)) {
+                // unexpected segment HL, CTT, AMT or SE
+                throw X12ParsingUtil.handleUnexpectedSegment("Beginning", currentSegment.getIdentifier());
+            } else {
+                // assuming that this
+                // segment is the beginning segment
+                genericTx.setBeginningSegment(currentSegment);
+            }
+        }
+        
+        //
+        // all segments that appear before the first HL loop
+        // 
+        this.parseSegmentsBeforeHierarchyLoops(segments, genericTx);
+        
+        //
+        // loops
+        //
+        this.handleLooping(segments, genericTx);
+        
+        //
+        // CTT or AMT
+        //
+        this.handleOptionalSegments(segments, genericTx);
+        
+        //
+        // SE
+        //
+        if (segments.hasNext()) {
+            currentSegment = segments.next();
+            this.parseTransactionSetTrailer(currentSegment, genericTx);
+        } else {
+            throw X12ParsingUtil.handleUnexpectedSegment("SE", "nothing");
+        }
+    }
+    
+    /**
+     * parse the segments
+     * that appear between the beginning segment
+     * and the first loop or the CTT or SE
+     * 
+     * it will also move the segment iterator to segment 
+     * that caused the looping to stop
+     * 
+     * @param segments
+     * @param txSet
+     * @throws X12ParserException if no HL loop is found
+     */
+    protected void parseSegmentsBeforeHierarchyLoops(SegmentIterator segments, GenericTransactionSet genericTx) {
+        
+        while (segments.hasNext()) {
+            X12Segment currentSegment = segments.next();
+            if (this.isEndOfSegmentsBeforeLoops(currentSegment)) {
+                // we should back up so
+                // the parser starts w/ this segment
+                segments.previous();
+                break;
+            } else {
+                // add segment to the transaction set
+                LOGGER.debug(currentSegment.getIdentifier());
+                genericTx.addX12Segment(currentSegment);
+            }
+        }
+    }
+    
+    /**
+     * checks for an HL loop, CTT or AMT or SE
+     * @return
+     */
+    private boolean isEndOfSegmentsBeforeLoops(X12Segment segment) {
+        return X12ParsingUtil.isHierarchalLoopStart(segment) 
+            || X12TransactionSet.TRANSACTION_ITEM_TOTAL.equals(segment.getIdentifier())
+            || X12TransactionSet.TRANSACTION_AMOUNT_TOTAL.equals(segment.getIdentifier())
+            || X12TransactionSet.TRANSACTION_SET_TRAILER.equals(segment.getIdentifier());
+    }
+    
+    /**
+     * checks for CTT or AMT
+     * @return
+     */
+    private void handleOptionalSegments(SegmentIterator segments, GenericTransactionSet genericTx) {
+        while (segments.hasNext()) {
+            X12Segment currentSegment = segments.next();
+            String segmentId = currentSegment.getIdentifier();
+            if (X12TransactionSet.TRANSACTION_ITEM_TOTAL.equals(segmentId)) {
+                this.parseTransactionTotals(currentSegment, genericTx);
+            } else if (X12TransactionSet.TRANSACTION_AMOUNT_TOTAL.equals(segmentId)) {
+                // TODO: AMT not supported yet
+            } else {
+                // was not CTT or AMT
+                // hopefully it is SE
+                segments.previous();
+                break;
+            }
+                
+        }
+    }
+    
+    protected void handleLooping(SegmentIterator segments, GenericTransactionSet genericTx) {
+        
+        if (segments.hasNext()) {
+            X12Segment currentSegment = segments.next();
+            if (X12ParsingUtil.isHierarchalLoopStart(currentSegment)) {
+                segments.previous();
+                int firstLoopSegmentIndex = segments.currentIndex();
+                int indexToSegmentAfterHierarchicalLoops = this.findIndexForSegmentAfterHierarchicalLoops(segments);
+                List<X12Segment> loopSegments = segments.subList(firstLoopSegmentIndex, indexToSegmentAfterHierarchicalLoops);
+                
+                // manage the loops
+                // assigning the parents and children accordingly
+                List<X12Loop> loops = X12ParsingUtil.findHierarchicalLoops(loopSegments);
+
+                // parse each of the loops
+                this.doLoopParsing(loops, genericTx);
+                
+                // we processed all of the loops 
+                // so now set the iteraror up
+                // so that the next segment after 
+                // the last loop is next
+                segments.reset(indexToSegmentAfterHierarchicalLoops);
+            } else {
+                // doesn't start w/ HL
+                // we should back it up 
+                // and let the parser deal w/ this
+                // segment
+                segments.previous();
+            }
+        }
+    }
+    
+    /**
+     * expects the current segment to be the first HL loop occurring 
+     * in the transaction set
+     */
+    private int findIndexForSegmentAfterHierarchicalLoops(SegmentIterator segments) {
+        int firstLoopSegmentIndex = segments.currentIndex();
+        int indexToSegmentAfterHierarchicalLoops = -1;
+        while (segments.hasNext()) {
+            X12Segment segment = segments.next();
+            if (X12TransactionSet.TRANSACTION_ITEM_TOTAL.equals(segment.getIdentifier())
+                || X12TransactionSet.TRANSACTION_AMOUNT_TOTAL.equals(segment.getIdentifier())
+                || X12TransactionSet.TRANSACTION_SET_TRAILER.equals(segment.getIdentifier())) {
+                // CTT segment or AMT segment or SE segment
+                indexToSegmentAfterHierarchicalLoops = segments.currentIndex() - 1;
+                break;
+            }
+        }
+        if (indexToSegmentAfterHierarchicalLoops == -1) {
+            indexToSegmentAfterHierarchicalLoops = segments.currentIndex() - 1;
+        }
+        
+        segments.reset(firstLoopSegmentIndex);
+        return indexToSegmentAfterHierarchicalLoops;
+    }
+    
+    protected void doLoopParsing(List<X12Loop> loops, GenericTransactionSet genericTx) {
+        genericTx.setLoops(loops);
+    }
+
+}

--- a/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericParserTest.java
@@ -1,0 +1,583 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.walmartlabs.x12.standard.txset.generic;
+
+import com.walmartlabs.x12.X12Document;
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.standard.InterchangeControlEnvelope;
+import com.walmartlabs.x12.standard.StandardX12Document;
+import com.walmartlabs.x12.standard.StandardX12Parser;
+import com.walmartlabs.x12.standard.X12Group;
+import com.walmartlabs.x12.standard.X12Loop;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * test the Generic Transaction Set parser when registered with the Standard X12
+ * parser
+ *
+ */
+public class GenericParserTest {
+
+    private StandardX12Parser standardParser;
+
+    @Before
+    public void init() {
+        standardParser = new StandardX12Parser();
+        standardParser.registerTransactionSetParser(new GenericTransactionSetParser());
+    }
+
+    @Test
+    public void test_Parsing_SourceIsNull() {
+        String sourceData = null;
+        X12Document x12 = standardParser.parse(sourceData);
+        assertNull(x12);
+    }
+
+    @Test
+    public void test_Parsing_SourceIsEmpty() {
+        String sourceData = "";
+        X12Document x12 = standardParser.parse(sourceData);
+        assertNull(x12);
+    }
+
+    @Test
+    public void test_Parsing_GenericDocument() {
+        String sourceData = this.genericX12Document();
+        StandardX12Document x12Doc = standardParser.parse(sourceData);
+        assertNotNull(x12Doc);
+
+        // ISA segment
+        this.assertEnvelopeHeader(x12Doc);
+
+        // Transaction Sets
+        List<X12TransactionSet> txForGroupOne = x12Doc.getGroups().get(0).getTransactions();
+        assertNotNull(txForGroupOne);
+        assertEquals(1, txForGroupOne.size());
+
+        // ST
+        GenericTransactionSet genericTx = (GenericTransactionSet) txForGroupOne.get(0);
+        assertEquals("YYZ", genericTx.getTransactionSetIdentifierCode());
+        assertEquals("0001", genericTx.getHeaderControlNumber());
+
+        // Beginning Segment Line
+        X12Segment beginSegment = genericTx.getBeginningSegment();
+        assertNotNull(beginSegment);
+        assertEquals("TOM", beginSegment.getIdentifier());
+        assertEquals("TOM", beginSegment.getElement(0));
+        assertEquals("00", beginSegment.getElement(1));
+        assertEquals(null, beginSegment.getElement(2));
+        assertEquals("2112", beginSegment.getElement(3));
+
+        // segments after the beginning segment 
+        // that appear before the loops
+        List<X12Segment> segments = genericTx.getSegmentsBeforeLoops();
+        assertNotNull(segments);
+        assertEquals(2, segments.size());
+        assertEquals("DTM", segments.get(0).getIdentifier());
+        assertEquals("19740301", segments.get(0).getElement(2));
+        
+        assertEquals("REF", segments.get(1).getIdentifier());
+        assertEquals("FISH", segments.get(1).getElement(2));
+        
+        // Loops
+        List<X12Loop> topLoops = genericTx.getLoops();
+        assertNotNull(topLoops);
+        assertEquals(2, topLoops.size());
+
+        //
+        // loop A
+        //
+        X12Loop loopA = topLoops.get(0);
+        assertNotNull(loopA);
+        assertEquals("A", loopA.getCode());
+        assertEquals("1", loopA.getHierarchicalId());
+        assertEquals(null, loopA.getParentHierarchicalId());
+
+        List<X12Segment> loopSegmentsForLoopA = loopA.getSegments();
+        assertNotNull(loopSegmentsForLoopA);
+        assertEquals(1, loopSegmentsForLoopA.size());
+        assertEquals("REF", loopSegmentsForLoopA.get(0).getIdentifier());
+        assertEquals("RED", loopSegmentsForLoopA.get(0).getElement(2));
+        
+        List<X12Loop> childLoopsForLoopA = loopA.getChildLoops();
+        assertNotNull(childLoopsForLoopA);
+        assertEquals(1, childLoopsForLoopA.size());
+        
+        //
+        // loop B 
+        // child of loop A
+        //
+        X12Loop loopB = childLoopsForLoopA.get(0);
+        assertNotNull(loopB);
+        assertEquals("B", loopB.getCode());
+        assertEquals("2", loopB.getHierarchicalId());
+        assertEquals("1", loopB.getParentHierarchicalId());
+
+        List<X12Segment> loopSegmentsForLoopB = loopB.getSegments();
+        assertNotNull(loopSegmentsForLoopB);
+        assertEquals(2, loopSegmentsForLoopB.size());
+        assertEquals("REF", loopSegmentsForLoopB.get(0).getIdentifier());
+        assertEquals("X", loopSegmentsForLoopB.get(0).getElement(3));
+        assertEquals("1", loopSegmentsForLoopB.get(0).getElement(4));
+        
+        assertEquals("REF", loopSegmentsForLoopB.get(1).getIdentifier());
+        assertEquals("X", loopSegmentsForLoopB.get(1).getElement(3));
+        assertEquals("2", loopSegmentsForLoopB.get(1).getElement(4));
+        
+        List<X12Loop> childLoopsForLoopB = loopB.getChildLoops();
+        assertNull(childLoopsForLoopB);
+        
+        //
+        // loop C
+        //
+        X12Loop loopC = topLoops.get(1);
+        assertNotNull(loopC);
+        assertEquals("C", loopC.getCode());
+        assertEquals("3", loopC.getHierarchicalId());
+        assertEquals(null, loopC.getParentHierarchicalId());
+
+        List<X12Segment> loopSegmentsForLoopC = loopC.getSegments();
+        assertNull(loopSegmentsForLoopC);
+
+        List<X12Loop> childLoopsForLoopC = loopC.getChildLoops();
+        assertNotNull(childLoopsForLoopC);
+        assertEquals(2, childLoopsForLoopC.size());
+        
+        //
+        // loop D
+        // child of loop C
+        //
+        X12Loop loopD = childLoopsForLoopC.get(0);
+        assertNotNull(loopD);
+        assertEquals("D", loopD.getCode());
+        assertEquals("4", loopD.getHierarchicalId());
+        assertEquals("3", loopD.getParentHierarchicalId());
+
+        List<X12Segment> loopSegmentsForLoopD = loopD.getSegments();
+        assertNotNull(loopSegmentsForLoopD);
+        assertEquals(1, loopSegmentsForLoopD.size());
+        assertEquals("REF", loopSegmentsForLoopD.get(0).getIdentifier());
+        assertEquals("SYRINX", loopSegmentsForLoopD.get(0).getElement(2));
+        
+        List<X12Loop> childLoopsForLoopD = loopD.getChildLoops();
+        assertNull(childLoopsForLoopD);
+        
+        
+        //
+        // loop E
+        // child of loop C
+        //
+        X12Loop loopE = childLoopsForLoopC.get(1);
+        assertNotNull(loopE);
+        assertEquals("E", loopE.getCode());
+        assertEquals("5", loopE.getHierarchicalId());
+        assertEquals("3", loopE.getParentHierarchicalId());
+
+        List<X12Segment> loopSegmentsForLoopE = loopE.getSegments();
+        assertNotNull(loopSegmentsForLoopE);
+        assertEquals(1, loopSegmentsForLoopE.size());
+        assertEquals("REF", loopSegmentsForLoopE.get(0).getIdentifier());
+        assertEquals("BY-TOR", loopSegmentsForLoopE.get(0).getElement(2));
+        
+        List<X12Loop> childLoopsForLoopE = loopE.getChildLoops();
+        assertNull(childLoopsForLoopE);
+        
+        // CTT
+        assertEquals(Integer.valueOf(0), genericTx.getTransactionLineItems());
+        
+        // SE
+        assertEquals(Integer.valueOf(8), genericTx.getExpectedNumberOfSegments());
+        assertEquals("0001", genericTx.getTrailerControlNumber());
+    }
+    
+    @Test
+    public void test_Parsing_PurchaseOrderDocument() {
+        String sourceData = this.samplePurchaseOrder();
+        StandardX12Document x12Doc = standardParser.parse(sourceData);
+        assertNotNull(x12Doc);
+        
+        // ISA segment
+        this.assertEnvelopeHeader(x12Doc);
+        
+        // Transaction Sets
+        List<X12TransactionSet> txForGroupOne = x12Doc.getGroups().get(0).getTransactions();
+        assertNotNull(txForGroupOne);
+        assertEquals(1, txForGroupOne.size());
+        
+        // ST
+        GenericTransactionSet genericTx = (GenericTransactionSet) txForGroupOne.get(0);
+        assertEquals("850", genericTx.getTransactionSetIdentifierCode());
+        assertEquals("000000010", genericTx.getHeaderControlNumber());
+
+        // Beginning Segment Line
+        X12Segment beginSegment = genericTx.getBeginningSegment();
+        assertNotNull(beginSegment);
+        assertEquals("BEG", beginSegment.getIdentifier());
+        assertEquals("00", beginSegment.getElement(1));
+        assertEquals("SA", beginSegment.getElement(2));
+        assertEquals("08292233294", beginSegment.getElement(3));
+        
+        // segments after the beginning segment 
+        // that appear before the loops
+        List<X12Segment> segments = genericTx.getSegmentsBeforeLoops();
+        assertNotNull(segments);
+        assertEquals(28, segments.size());
+        
+        assertEquals("REF", segments.get(0).getIdentifier());
+        assertEquals("DP", segments.get(0).getElement(1));
+        assertEquals("038", segments.get(0).getElement(2));
+        
+        // PID*F****SMALL WIDGET
+        assertEquals("PID", segments.get(11).getIdentifier());
+        assertEquals("F", segments.get(11).getElement(1));
+        assertEquals("SMALL WIDGET", segments.get(11).getElement(5));
+        
+        // Loops
+        List<X12Loop> topLoops = genericTx.getLoops();
+        assertNull(topLoops);
+        
+        // CTT
+        assertEquals(Integer.valueOf(6), genericTx.getTransactionLineItems());
+        
+        // SE
+        assertEquals(Integer.valueOf(33), genericTx.getExpectedNumberOfSegments());
+        assertEquals("000000010", genericTx.getTrailerControlNumber());
+    }
+    
+    @Test
+    public void test_Parsing_AdvanceShipNoticeDocument() {
+        String sourceData = this.sampleAdvanceShipNotice();
+        StandardX12Document x12Doc = standardParser.parse(sourceData);
+        assertNotNull(x12Doc);
+        
+        // ISA segment
+        this.assertEnvelopeHeader(x12Doc);
+        
+        // Transaction Sets
+        List<X12TransactionSet> txForGroupOne = x12Doc.getGroups().get(0).getTransactions();
+        assertNotNull(txForGroupOne);
+        assertEquals(1, txForGroupOne.size());
+        
+        // ST
+        GenericTransactionSet genericTx = (GenericTransactionSet) txForGroupOne.get(0);
+        assertEquals("856", genericTx.getTransactionSetIdentifierCode());
+        assertEquals("0001", genericTx.getHeaderControlNumber());
+
+        // Beginning Segment Line
+        X12Segment beginSegment = genericTx.getBeginningSegment();
+        assertNotNull(beginSegment);
+        assertEquals("BSN", beginSegment.getIdentifier());
+        assertEquals("00", beginSegment.getElement(1));
+        assertEquals("2820967", beginSegment.getElement(2));
+        assertEquals("20210329", beginSegment.getElement(3));
+
+        // segments after the beginning segment 
+        // that appear before the loops
+        List<X12Segment> segments = genericTx.getSegmentsBeforeLoops();
+        assertNull(segments);
+        
+        // Loops
+        List<X12Loop> topLoops = genericTx.getLoops();
+        assertNotNull(topLoops);
+        assertEquals(1, topLoops.size());
+        
+        // Shipment 
+        X12Loop shipmentLoop = topLoops.get(0);
+        assertNotNull(shipmentLoop);
+        assertEquals("S", shipmentLoop.getCode());
+        assertEquals("1", shipmentLoop.getHierarchicalId());
+        assertEquals(null, shipmentLoop.getParentHierarchicalId());
+
+        List<X12Segment> shipmentSegments = shipmentLoop.getSegments();
+        assertNotNull(shipmentSegments);
+        assertEquals(9, shipmentSegments.size());
+        assertEquals("N1", shipmentSegments.get(5).getIdentifier());
+        assertEquals("SF", shipmentSegments.get(5).getElement(1));
+        assertEquals("Sunkist Growers Inc", shipmentSegments.get(5).getElement(2));
+        
+        List<X12Loop> orderLoops = shipmentLoop.getChildLoops();
+        assertNotNull(orderLoops);
+        assertEquals(1, orderLoops.size());
+        
+        // Order 
+        X12Loop orderLoop = orderLoops.get(0);
+        assertNotNull(orderLoop);
+        assertEquals("O", orderLoop.getCode());
+        assertEquals("2", orderLoop.getHierarchicalId());
+        assertEquals("1", orderLoop.getParentHierarchicalId());
+
+        List<X12Segment> orderSegments = orderLoop.getSegments();
+        assertNotNull(orderSegments);
+        assertEquals(4, orderSegments.size());
+        assertEquals("REF", orderSegments.get(2).getIdentifier());
+        assertEquals("IA", orderSegments.get(2).getElement(1));
+        assertEquals("694349942", orderSegments.get(2).getElement(2));
+        
+        List<X12Loop> batchLoops = orderLoop.getChildLoops();
+        assertNotNull(batchLoops);
+        assertEquals(1, batchLoops.size());
+        
+        // Batch 
+        X12Loop batchLoop = batchLoops.get(0);
+        assertNotNull(batchLoop);
+        assertEquals("ZZ", batchLoop.getCode());
+        assertEquals("3", batchLoop.getHierarchicalId());
+        assertEquals("2", batchLoop.getParentHierarchicalId());
+
+        List<X12Segment> batchSegments = batchLoop.getSegments();
+        assertNotNull(batchSegments);
+        assertEquals(3, batchSegments.size());
+        assertEquals("LIN", batchSegments.get(0).getIdentifier());
+        assertEquals("LT", batchSegments.get(0).getElement(2));
+        assertEquals("BBC", batchSegments.get(0).getElement(3));
+        
+        List<X12Loop> batchLoopChildren = batchLoop.getChildLoops();
+        assertNull(batchLoopChildren);
+        
+        // CTT
+        assertEquals(Integer.valueOf(3), genericTx.getTransactionLineItems());
+        
+        // SE
+        assertEquals(Integer.valueOf(23), genericTx.getExpectedNumberOfSegments());
+        assertEquals("0001", genericTx.getTrailerControlNumber());
+    }
+    
+    private String genericX12Document() {
+        return new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABC*ZZ*123456789012345*101127*1719*U*00400*000003438*0*P*>")
+            .append("\n")
+            .append("GS*SH*0000000000*999999999*20210408*1045*00*X*005010")
+            .append("\n")
+            .append("ST*YYZ*0001")
+            .append("\n")
+            .append("TOM*00**2112")
+            .append("\n")
+            .append("DTM*00*19740301")
+            .append("\n")
+            .append("REF*42*FISH")
+            .append("\n")
+            .append("HL*1**A")  // 1st top level loop (A)
+            .append("\n")
+            .append("REF*XX*RED*SECTOR*A")
+            .append("\n")
+            .append("HL*2*1*B")  // child of A
+            .append("\n")
+            .append("REF*XX*CYGNUS*X*1")
+            .append("\n")
+            .append("REF*YY*CYGNUS*X*2")
+            .append("\n")
+            .append("HL*3**C")  // 2nd top level loop (C)
+            .append("\n")
+            .append("HL*4*3*D")  // child of C
+            .append("\n")
+            .append("REF*XX*SYRINX")
+            .append("\n")
+            .append("HL*5*3*E")  // child of C
+            .append("\n")
+            .append("REF*XX*BY-TOR")
+            .append("\n")
+            .append("CTT*00")
+            .append("\n")
+            .append("SE*8*0001")
+            .append("\n")
+            .append("GE*1*00")
+            .append("\n")
+            .append("IEA*1*000003438")
+            .toString();
+    }
+
+    /**
+     * Based on sample
+     * https://www.1edisource.com/resources/edi-transactions-sets/edi-850/
+     */
+    private String samplePurchaseOrder() {
+        return new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABC*ZZ*123456789012345*101127*1719*U*00400*000003438*0*P*>")
+            .append("\n")
+            .append("GS*PO*4405197800*999999999*20101127*1719*1421*X*004010VICS")
+            .append("\n")
+            .append("ST*850*000000010")
+            .append("\n")
+            .append("BEG*00*SA*08292233294**20101127*610385385")
+            .append("\n")
+            .append("REF*DP*038")
+            .append("\n")
+            .append("REF*PS*R")
+            .append("\n")
+            .append("ITD*14*3*2**45**46")
+            .append("\n")
+            .append("DTM*002*20101214")
+            .append("\n")
+            .append("PKG*F*68***PALLETIZE SHIPMENT")
+            .append("\n")
+            .append("PKG*F*66***REGULAR")
+            .append("\n")
+            .append("TD5*A*92*P3**SEE XYZ RETAIL ROUTING GUIDE")
+            .append("\n")
+            .append("N1*ST*XYZ RETAIL*9*0003947268292")
+            .append("\n")
+            .append("N3*31875 SOLON RD")
+            .append("\n")
+            .append("N4*SOLON*OH*44139")
+            .append("\n")
+            .append("PO1*1*120*EA*9.25*TE*CB*065322-117*PR*RO*VN*AB3542")
+            .append("\n")
+            .append("PID*F****SMALL WIDGET")
+            .append("\n")
+            .append("PO4*4*4*EA*PLT94**3*LR*15*CT")
+            .append("\n")
+            .append("PO1*2*220*EA*13.79*TE*CB*066850-116*PR*RO*VN*RD5322")
+            .append("\n")
+            .append("PID*F****MEDIUM WIDGET")
+            .append("\n")
+            .append("PO4*2*2*EA")
+            .append("\n")
+            .append("PO1*3*126*EA*10.99*TE*CB*060733-110*PR*RO*VN*XY5266")
+            .append("\n")
+            .append("PID*F****LARGE WIDGET")
+            .append("\n")
+            .append("PO4*6*1*EA*PLT94**3*LR*12*CT")
+            .append("\n")
+            .append("PO1*4*76*EA*4.35*TE*CB*065308-116*PR*RO*VN*VX2332")
+            .append("\n")
+            .append("PID*F****NANO WIDGET")
+            .append("\n")
+            .append("PO4*4*4*EA*PLT94**6*LR*19*CT")
+            .append("\n")
+            .append("PO1*5*72*EA*7.5*TE*CB*065374-118*PR*RO*VN*RV0524")
+            .append("\n")
+            .append("PID*F****BLUE WIDGET")
+            .append("\n")
+            .append("PO4*4*4*EA")
+            .append("\n")
+            .append("PO1*6*696*EA*9.55*TE*CB*067504-118*PR*RO*VN*DX1875")
+            .append("\n")
+            .append("PID*F****ORANGE WIDGET")
+            .append("\n")
+            .append("PO4*6*6*EA*PLT94**3*LR*10*CT")
+            .append("\n")
+            .append("CTT*6")
+            .append("\n")
+            .append("AMT*1*13045.94")
+            .append("\n")
+            .append("SE*33*000000010")
+            .append("\n")
+            .append("GE*1*1421")
+            .append("\n")
+            .append("IEA*1*000003438")
+            .append("\n")
+            .toString();
+    }
+
+    private String sampleAdvanceShipNotice() {
+        return new StringBuilder()
+            .append("ISA*01*0000000000*01*0000000000*ZZ*ABC*ZZ*123456789012345*101127*1719*U*00400*000003438*0*P*>")
+            .append("\n")
+            .append("GS*PO*4405197800*999999999*20101127*1719*1421*X*004010VICS")
+            .append("\n")
+            .append("ST*856*0001")
+            .append("\n")
+            .append("BSN*00*2820967*20210329*2226*ZZZZ")
+            .append("\n")
+            .append("HL*1**S")
+            .append("\n")
+            .append("TD1**160****G*6256*LB")
+            .append("\n")
+            .append("TD5**2*WALMRT")
+            .append("\n")
+            .append("REF*UCB*60504900000438841")
+            .append("\n")
+            .append("DTM*011*20210329")
+            .append("\n")
+            .append("FOB*PP")
+            .append("\n")
+            .append("N1*SF*Sunkist Growers Inc*UL*0605049000013")
+            .append("\n")
+            .append("N3*27770 N. Entertainment Drive")
+            .append("\n")
+            .append("N4*Valencia*CA*91355-1092")
+            .append("\n")
+            .append("N1*ST*WAL-MART GROCERY DC #6057*UL*0078742033808")
+            .append("\n")
+            .append("HL*2*1*O")
+            .append("\n")
+            .append("SN1**160*CA")
+            .append("\n")
+            .append("PRF*0558834757***20210323")
+            .append("\n")
+            .append("REF*IA*694349942")
+            .append("\n")
+            .append("REF*IV*438841")
+            .append("\n")
+            .append("HL*3*2*ZZ")
+            .append("\n")
+            .append("LIN**LT*BBC")
+            .append("\n")
+            .append("SN1**32*EA")
+            .append("\n")
+            .append("DTM*510*20210329")
+            .append("\n")
+            .append("CTT*3")
+            .append("\n")
+            .append("SE*23*0001")
+            .append("\n")
+            .append("GE*1*1421")
+            .append("\n")
+            .append("IEA*1*000003438")
+            .append("\n")
+            .toString();
+    }
+    
+    private void assertEnvelopeHeader(StandardX12Document x12Doc) {
+        // ISA segment
+        InterchangeControlEnvelope isa = x12Doc.getInterchangeControlEnvelope();
+        assertNotNull(isa);
+        assertEquals("01", isa.getAuthorizationInformationQualifier());
+        assertEquals("0000000000", isa.getAuthorizationInformation());
+        assertEquals("01", isa.getSecurityInformationQualifier());
+        assertEquals("0000000000", isa.getSecurityInformation());
+        assertEquals("ZZ", isa.getInterchangeIdQualifier());
+        assertEquals("ABC", isa.getInterchangeSenderId());
+        assertEquals("ZZ", isa.getInterchangeIdQualifierTwo());
+        assertEquals("123456789012345", isa.getInterchangeReceiverId());
+        assertEquals("101127", isa.getInterchangeDate());
+        assertEquals("1719", isa.getInterchangeTime());
+        assertEquals("U", isa.getInterchangeControlStandardId());
+        assertEquals("00400", isa.getInterchangeControlVersion());
+        assertEquals("000003438", isa.getInterchangeControlNumber());
+        assertEquals("0", isa.getAcknowledgementRequested());
+        assertEquals("P", isa.getUsageIndicator());
+        assertEquals(">", isa.getElementSeparator());
+        
+        // Groups
+        assertEquals(new Integer(1), isa.getNumberOfGroups());
+        assertEquals("000003438", isa.getTrailerInterchangeControlNumber());
+
+        List<X12Group> groups = x12Doc.getGroups();
+        assertNotNull(groups);
+        assertEquals(1, groups.size());
+    }
+
+}

--- a/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParserTest.java
@@ -1,0 +1,198 @@
+package com.walmartlabs.x12.standard.txset.generic;
+
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.exceptions.X12ParserException;
+import com.walmartlabs.x12.standard.X12Group;
+import com.walmartlabs.x12.standard.X12Loop;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GenericTransactionSetParserTest {
+
+
+    private GenericTransactionSetParser txParser;
+    
+    @Before
+    public void init() {
+        txParser = new GenericTransactionSetParser();
+    }
+    
+    /**
+     * the generic parser always handles the transaction set
+     */
+    @Test
+    public void test_handlesTransactionSet() {
+        X12Group x12Group = null;
+        List<X12Segment> segments = null;
+        assertTrue(txParser.handlesTransactionSet(segments, x12Group));
+    }
+    
+    @Test
+    public void test_doParse_null() {
+        X12Group x12Group = new X12Group();
+        List<X12Segment> segments = null;
+        X12TransactionSet txSet = txParser.doParse(segments, x12Group);
+        assertNull(txSet);
+    }
+    
+    @Test
+    public void test_doParse_empty() {
+        X12Group x12Group = new X12Group();
+        List<X12Segment> segments = Collections.emptyList();
+        X12TransactionSet txSet = txParser.doParse(segments, x12Group);
+        assertNull(txSet);
+    }
+    
+    @Test
+    public void test_doParse_OnlyTransactionEnvelope() {
+        try {
+            X12Group x12Group = new X12Group();
+            List<X12Segment> segments = this.getSegmentsOnlyTransactionEnvelope();
+            txParser.doParse(segments, x12Group);
+            fail("expected parsing exception");
+        } catch (X12ParserException e) {
+            assertEquals("expected Beginning segment but found SE", e.getMessage());
+        }
+    }
+    
+    @Test
+    public void test_doParse_NoHierarchicalLoops() {
+        X12Group x12Group = new X12Group();
+        List<X12Segment> segments = this.getSegmentsNoHierarchicalLoops();
+        X12TransactionSet txSet = txParser.doParse(segments, x12Group);
+        assertNotNull(txSet);
+        
+        GenericTransactionSet genericTx = (GenericTransactionSet) txSet;
+        assertEquals("BSN",genericTx.getBeginningSegment().getElement(0));
+        assertEquals("05755986",genericTx.getBeginningSegment().getElement(2));
+        
+        List<X12Segment> segmentsBeforeLoop = genericTx.getSegmentsBeforeLoops();
+        assertNull(segmentsBeforeLoop);
+        
+        List<X12Loop> loops = genericTx.getLoops();
+        assertNull(loops);
+    }
+    
+    @Test
+    public void test_doParse_TwoTopLevelHierarchicalLoops() {
+        X12Group x12Group = new X12Group();
+        List<X12Segment> segments = this.getTwoShipmentLoops();
+        X12TransactionSet txSet = txParser.doParse(segments, x12Group);
+        assertNotNull(txSet);
+        
+        GenericTransactionSet genericTx = (GenericTransactionSet) txSet;
+        assertEquals("BSN",genericTx.getBeginningSegment().getElement(0));
+        assertEquals("05755986",genericTx.getBeginningSegment().getElement(2));
+        
+        List<X12Segment> segmentsBeforeLoop = genericTx.getSegmentsBeforeLoops();
+        assertNull(segmentsBeforeLoop);
+        
+        List<X12Loop> loops = genericTx.getLoops();
+        assertNotNull(loops);
+        assertEquals(2, loops.size());
+    }
+    
+    @Test
+    public void test_doParse_UnexpectedSegmentBeforeHierarchicalLoops() {
+        X12Group x12Group = new X12Group();
+        List<X12Segment> segments = this.getSegmentBeforeHierarchicalLoops();
+        X12TransactionSet txSet = txParser.doParse(segments, x12Group);
+        assertNotNull(txSet);
+        
+        GenericTransactionSet genericTx = (GenericTransactionSet) txSet;
+        assertEquals("BSN",genericTx.getBeginningSegment().getElement(0));
+        assertEquals("05755986",genericTx.getBeginningSegment().getElement(2));
+        
+        List<X12Segment> segmentsBeforeLoop = genericTx.getSegmentsBeforeLoops();
+        assertNotNull(segmentsBeforeLoop);
+        assertEquals(2, segmentsBeforeLoop.size());
+        
+        assertEquals("DTM", segmentsBeforeLoop.get(0).getIdentifier());
+        assertEquals("REF", segmentsBeforeLoop.get(1).getIdentifier());
+        
+        List<X12Loop> loops = genericTx.getLoops();
+        assertNotNull(loops);
+        assertEquals(1, loops.size());
+    }
+    
+    @Test
+    public void test_doParse() {
+        X12Group x12Group = new X12Group();
+        List<X12Segment> segments = this.getTestSegments();
+        X12TransactionSet txSet = txParser.doParse(segments, x12Group);
+        assertNotNull(txSet);
+        
+        GenericTransactionSet genericTx = (GenericTransactionSet) txSet;
+        assertEquals("BSN",genericTx.getBeginningSegment().getElement(0));
+        assertEquals("05755986",genericTx.getBeginningSegment().getElement(2));
+        List<X12Segment> segmentsBeforeLoop = genericTx.getSegmentsBeforeLoops();
+        assertNull(segmentsBeforeLoop);
+    }
+    
+    private List<X12Segment> getSegmentsOnlyTransactionEnvelope() {
+        List<X12Segment> txSegments = new ArrayList<>();
+        
+        txSegments.add(new X12Segment("ST*856*368090001"));
+        txSegments.add(new X12Segment("SE*296*368090001"));
+        
+        return txSegments;
+    }
+    
+    private List<X12Segment> getSegmentsNoHierarchicalLoops() {
+        List<X12Segment> txSegments = new ArrayList<>();
+        
+        txSegments.add(new X12Segment("ST*856*368090001"));
+        txSegments.add(new X12Segment("BSN*00*05755986*20190523*171543*0002"));
+        txSegments.add(new X12Segment("SE*296*368090001"));
+        
+        return txSegments;
+    }
+    
+    private List<X12Segment> getTwoShipmentLoops() {
+        List<X12Segment> txSegments = new ArrayList<>();
+        
+        txSegments.add(new X12Segment("ST*856*368090001"));
+        txSegments.add(new X12Segment("BSN*00*05755986*20190523*171543*0002"));
+        txSegments.add(new X12Segment("HL*1**S"));
+        txSegments.add(new X12Segment("HL*2**S"));
+        txSegments.add(new X12Segment("SE*296*368090001"));
+        
+        return txSegments;
+    }
+    
+    private List<X12Segment> getSegmentBeforeHierarchicalLoops() {
+        List<X12Segment> txSegments = new ArrayList<>();
+        
+        txSegments.add(new X12Segment("ST*856*368090001"));
+        txSegments.add(new X12Segment("BSN*00*05755986*20190523*171543*0002"));
+        txSegments.add(new X12Segment("DTM*067*20210323"));
+        txSegments.add(new X12Segment("REF*ZZ*420554090"));
+        txSegments.add(new X12Segment("HL*1**S"));
+        txSegments.add(new X12Segment("SE*296*368090001"));
+        
+        return txSegments;
+    }
+    
+    private List<X12Segment> getTestSegments() {
+        List<X12Segment> txSegments = new ArrayList<>();
+        
+        txSegments.add(new X12Segment("ST*856*368090001"));
+        txSegments.add(new X12Segment("BSN*00*05755986*20190523*171543*0002"));
+        txSegments.add(new X12Segment("HL*1**S"));
+        txSegments.add(new X12Segment("SE*296*368090001"));
+        
+        return txSegments;
+    }
+    
+}

--- a/src/test/java/sample/yyz/TypeYyzTransactionSet.java
+++ b/src/test/java/sample/yyz/TypeYyzTransactionSet.java
@@ -32,6 +32,7 @@ public class TypeYyzTransactionSet implements X12TransactionSet {
     private String trailerControlNumber;
     private Integer numSegments;
     private String value;
+    private Integer transactionLineItems;
 
     @Override
     public String getTransactionSetIdentifierCode() {
@@ -81,5 +82,14 @@ public class TypeYyzTransactionSet implements X12TransactionSet {
         this.value = value;
     }
 
-    
+    @Override
+    public Integer getTransactionLineItems() {
+        return transactionLineItems;
+    }
+
+    @Override
+    public void setTransactionLineItems(Integer transactionLineItems) {
+        this.transactionLineItems = transactionLineItems;
+    }
+
 }


### PR DESCRIPTION
Added a new `GenericTransactionSet` and `GenericTransactionSetParser`
This resulted in following
- moved CTT to AbstractTransactionSet*
- refactor of loop handling in AsnTxSetParser

Proposing new package structure (would move other classes in 0.4)

*.common
*.dex
*.dex.894
*.standard
*.standard.txset.generic  <--- new code was added here
*.standard.txset.asn856  <--- this would move to here from *.asn856
*.standard.txset.po850    <--- this would move to here from *.po850


