### PR TITLE
part 1 - add ASN segments from standard guide

### DIFF
--- a/src/main/java/com/walmartlabs/x12/SegmentIterator.java
+++ b/src/main/java/com/walmartlabs/x12/SegmentIterator.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12;
 
 import java.util.List;

--- a/src/main/java/com/walmartlabs/x12/SegmentIterator.java
+++ b/src/main/java/com/walmartlabs/x12/SegmentIterator.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12;
 
 import java.util.List;

--- a/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
+++ b/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12;
 
 import com.walmartlabs.x12.dex.dx894.DefaultDex894Parser;

--- a/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
+++ b/src/main/java/com/walmartlabs/x12/X12ParsingUtil.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12;
 
 import com.walmartlabs.x12.dex.dx894.DefaultDex894Parser;

--- a/src/main/java/com/walmartlabs/x12/asn856/Item.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/Item.java
@@ -17,8 +17,10 @@ limitations under the License.
 package com.walmartlabs.x12.asn856;
 
 import com.walmartlabs.x12.asn856.segment.SN1ItemDetail;
+import com.walmartlabs.x12.common.segment.DTMDateTimeReference;
 import com.walmartlabs.x12.common.segment.LINItemIdentification;
 import com.walmartlabs.x12.common.segment.PIDProductIdentification;
+import com.walmartlabs.x12.common.segment.REFReferenceInformation;
 import com.walmartlabs.x12.standard.X12Loop;
 import com.walmartlabs.x12.standard.X12ParsedLoop;
 import org.springframework.util.CollectionUtils;
@@ -46,6 +48,14 @@ public class Item extends X12ParsedLoop {
      * LIN: Item Identification
      */
     private List<LINItemIdentification> itemIdentifications;
+    /*
+     * REF: references
+     */
+    private List<REFReferenceInformation> refList;
+    /*
+     * DTM: Date/Time Reference
+     */
+    List<DTMDateTimeReference> dtmReferences;
 
     public static boolean isItemLoop(X12Loop loop) {
         return X12Loop.isLoopWithCode(loop, ITEM__LOOP_CODE);
@@ -75,6 +85,29 @@ public class Item extends X12ParsedLoop {
         productIdentifications.add(pid);
     }
 
+    /**
+     * helper method to add REF
+     * 
+     * @param ref
+     */
+    public void addReferenceInformation(REFReferenceInformation ref) {
+        if (CollectionUtils.isEmpty(refList)) {
+            refList = new ArrayList<>();
+        }
+        refList.add(ref);
+    }
+    
+    /**
+     * helper method to add DTM to list
+     * @param dtm
+     */
+    public void addDTMDateTimeReference(DTMDateTimeReference dtm) {
+        if (CollectionUtils.isEmpty(dtmReferences)) {
+            dtmReferences = new ArrayList<>();
+        }
+        dtmReferences.add(dtm);
+    }
+    
     public SN1ItemDetail getSn1() {
         return sn1;
     }
@@ -99,4 +132,19 @@ public class Item extends X12ParsedLoop {
         this.productIdentifications = productIdentifications;
     }
     
+    public List<DTMDateTimeReference> getDtmReferences() {
+        return dtmReferences;
+    }
+
+    public void setDtmReferences(List<DTMDateTimeReference> dtmReferences) {
+        this.dtmReferences = dtmReferences;
+    }
+
+    public List<REFReferenceInformation> getRefList() {
+        return refList;
+    }
+
+    public void setRefList(List<REFReferenceInformation> refList) {
+        this.refList = refList;
+    }
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/Order.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/Order.java
@@ -18,6 +18,7 @@ package com.walmartlabs.x12.asn856;
 
 import com.walmartlabs.x12.asn856.segment.PRFPurchaseOrderReference;
 import com.walmartlabs.x12.common.segment.REFReferenceInformation;
+import com.walmartlabs.x12.common.segment.TD1CarrierDetail;
 import com.walmartlabs.x12.standard.X12Loop;
 import com.walmartlabs.x12.standard.X12ParsedLoop;
 import org.springframework.util.CollectionUtils;
@@ -37,6 +38,11 @@ public class Order extends X12ParsedLoop {
      * PRF: Purchase Order Ref
      */
     private PRFPurchaseOrderReference prf;
+
+    /*
+     * TD1: Carrier Details
+     */
+    private TD1CarrierDetail td1;
 
     /*
      * REF
@@ -73,6 +79,14 @@ public class Order extends X12ParsedLoop {
 
     public void setRefList(List<REFReferenceInformation> refList) {
         this.refList = refList;
+    }
+    
+    public TD1CarrierDetail getTd1() {
+        return td1;
+    }
+
+    public void setTd1(TD1CarrierDetail td1) {
+        this.td1 = td1;
     }
 
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/Pack.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/Pack.java
@@ -20,6 +20,7 @@ import com.walmartlabs.x12.asn856.segment.MANMarkNumber;
 import com.walmartlabs.x12.asn856.segment.PO4ItemPhysicalDetail;
 import com.walmartlabs.x12.asn856.segment.SN1ItemDetail;
 import com.walmartlabs.x12.common.segment.LINItemIdentification;
+import com.walmartlabs.x12.common.segment.N1PartyIdentification;
 import com.walmartlabs.x12.common.segment.PIDProductIdentification;
 import com.walmartlabs.x12.common.segment.TD1CarrierDetail;
 import com.walmartlabs.x12.standard.X12Loop;
@@ -40,7 +41,11 @@ public class Pack extends X12ParsedLoop {
     /*
      * MAN: Marking
      */
-    private MANMarkNumber man;
+    private List<MANMarkNumber> manList;
+    /*
+     * N1: Party Identifiers
+     */
+    private N1PartyIdentification n1PartyIdentification;
     /*
      * PO4: Item Physical Details
      */
@@ -91,20 +96,25 @@ public class Pack extends X12ParsedLoop {
         productIdentifications.add(pid);
     }
     
+    /**
+     * helper method to add MAN
+     * 
+     * @param man
+     */
+    public void addMANMarkNumber(MANMarkNumber man) {
+        if (CollectionUtils.isEmpty(manList)) {
+            manList = new ArrayList<>();
+        }
+        manList.add(man);
+    }
+
+    
     public PO4ItemPhysicalDetail getPo4() {
         return po4;
     }
 
     public void setPo4(PO4ItemPhysicalDetail po4) {
         this.po4 = po4;
-    }
-
-    public MANMarkNumber getMan() {
-        return man;
-    }
-
-    public void setMan(MANMarkNumber man) {
-        this.man = man;
     }
 
     public List<PIDProductIdentification> getProductIdentifications() {
@@ -137,6 +147,22 @@ public class Pack extends X12ParsedLoop {
 
     public void setTd1(TD1CarrierDetail td1) {
         this.td1 = td1;
+    }
+
+    public N1PartyIdentification getN1PartyIdentification() {
+        return n1PartyIdentification;
+    }
+
+    public void setN1PartyIdentification(N1PartyIdentification n1PartyIdentification) {
+        this.n1PartyIdentification = n1PartyIdentification;
+    }
+
+    public List<MANMarkNumber> getManList() {
+        return manList;
+    }
+
+    public void setManList(List<MANMarkNumber> manList) {
+        this.manList = manList;
     }
     
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/Tare.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/Tare.java
@@ -21,6 +21,10 @@ import com.walmartlabs.x12.asn856.segment.PALPalletType;
 import com.walmartlabs.x12.common.segment.PKGPackaging;
 import com.walmartlabs.x12.standard.X12Loop;
 import com.walmartlabs.x12.standard.X12ParsedLoop;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Represents the Tare (Pallet) level of information
@@ -37,16 +41,40 @@ public class Tare extends X12ParsedLoop {
     /*
      * PKG: Packaging
      */
-    private PKGPackaging pkg;
+    private List<PKGPackaging> pkgList;
     /*
      * MAN: Marking
      */
-    private MANMarkNumber man;
+    private List<MANMarkNumber> manList;
 
     public static boolean isTareLoop(X12Loop loop) {
         return X12Loop.isLoopWithCode(loop, TARE_LOOP_CODE);
     }
+    
+    /**
+     * helper method to add MAN
+     * 
+     * @param man
+     */
+    public void addMANMarkNumber(MANMarkNumber man) {
+        if (CollectionUtils.isEmpty(manList)) {
+            manList = new ArrayList<>();
+        }
+        manList.add(man);
+    }
 
+    /**
+     * helper method to add PKG
+     * 
+     * @param pkg
+     */
+    public void addPKGPackaging(PKGPackaging pkg) {
+        if (CollectionUtils.isEmpty(pkgList)) {
+            pkgList = new ArrayList<>();
+        }
+        pkgList.add(pkg);
+    }
+    
     public PALPalletType getPal() {
         return pal;
     }
@@ -55,20 +83,20 @@ public class Tare extends X12ParsedLoop {
         this.pal = pal;
     }
 
-    public PKGPackaging getPkg() {
-        return pkg;
+    public List<PKGPackaging> getPkgList() {
+        return pkgList;
     }
 
-    public void setPkg(PKGPackaging pkg) {
-        this.pkg = pkg;
+    public void setPkgList(List<PKGPackaging> pkgList) {
+        this.pkgList = pkgList;
     }
 
-    public MANMarkNumber getMan() {
-        return man;
+    public List<MANMarkNumber> getManList() {
+        return manList;
     }
 
-    public void setMan(MANMarkNumber man) {
-        this.man = man;
+    public void setManList(List<MANMarkNumber> manList) {
+        this.manList = manList;
     }
-
+    
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/MANMarkNumber.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/MANMarkNumber.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.asn856.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/MANMarkNumber.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/MANMarkNumber.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/PALPalletType.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/PALPalletType.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/PALPalletType.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/PALPalletType.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.asn856.segment;
 
 /**
@@ -9,5 +24,28 @@ public class PALPalletType {
 
     public static final String IDENTIFIER = "PAL";
 
-    // TODO: implement
+    // PAL02
+    private String palletTiers;
+    
+    // PAL03
+    private String palletBlocks;
+    
+
+    public String getPalletTiers() {
+        return palletTiers;
+    }
+
+    public void setPalletTiers(String palletTiers) {
+        this.palletTiers = palletTiers;
+    }
+
+    public String getPalletBlocks() {
+        return palletBlocks;
+    }
+
+    public void setPalletBlocks(String palletBlocks) {
+        this.palletBlocks = palletBlocks;
+    }
+    
+    
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/PO4ItemPhysicalDetail.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/PO4ItemPhysicalDetail.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/PO4ItemPhysicalDetail.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/PO4ItemPhysicalDetail.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.asn856.segment;
 
 /**
@@ -8,6 +23,60 @@ package com.walmartlabs.x12.asn856.segment;
 public class PO4ItemPhysicalDetail {
 
     public static final String IDENTIFIER = "PO4";
+
+    // PO410
+    private String length;
     
-    // TODO: implement
+    // PO411
+    private String width;
+    
+    // PO412
+    private String height;
+    
+    // PO413
+    private String unitOfMeasurement;
+    
+    // PO416
+    private String assignedIdentification;
+
+    public String getLength() {
+        return length;
+    }
+
+    public void setLength(String length) {
+        this.length = length;
+    }
+
+    public String getWidth() {
+        return width;
+    }
+
+    public void setWidth(String width) {
+        this.width = width;
+    }
+
+    public String getHeight() {
+        return height;
+    }
+
+    public void setHeight(String height) {
+        this.height = height;
+    }
+
+    public String getUnitOfMeasurement() {
+        return unitOfMeasurement;
+    }
+
+    public void setUnitOfMeasurement(String uom) {
+        this.unitOfMeasurement = uom;
+    }
+
+    public String getAssignedIdentification() {
+        return assignedIdentification;
+    }
+
+    public void setAssignedIdentification(String assignedIdentification) {
+        this.assignedIdentification = assignedIdentification;
+    }
+    
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/PRFPurchaseOrderReference.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/PRFPurchaseOrderReference.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.asn856.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/PRFPurchaseOrderReference.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/PRFPurchaseOrderReference.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/SN1ItemDetail.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/SN1ItemDetail.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.asn856.segment;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/SN1ItemDetail.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/SN1ItemDetail.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/parser/PALPalletTypeParser.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/parser/PALPalletTypeParser.java
@@ -13,34 +13,34 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;
-import com.walmartlabs.x12.asn856.segment.SN1ItemDetail;
-import com.walmartlabs.x12.util.ConversionUtil;
+import com.walmartlabs.x12.asn856.segment.PALPalletType;
 
-public class SN1ItemDetailParser {
+public final class PALPalletTypeParser {
 
     /**
      * parse the segment
      * @param segment
      * @return
      */
-    public static SN1ItemDetail parse(X12Segment segment) {
-        SN1ItemDetail sn1 = null;
+    public static PALPalletType parse(X12Segment segment) {
+        PALPalletType pal = null;
 
         if (segment != null) {
             String segmentIdentifier = segment.getIdentifier();
-            if (SN1ItemDetail.IDENTIFIER.equals(segmentIdentifier)) {
-                sn1 = new SN1ItemDetail();
-                sn1.setNumberOfUnits(ConversionUtil.convertStringToBigDecimal(segment.getElement(2), 6));
-                sn1.setUnitOfMeasurement(segment.getElement(3));
+            if (PALPalletType.IDENTIFIER.equals(segmentIdentifier)) {
+                pal = new PALPalletType();
+                pal.setPalletTiers(segment.getElement(2));
+                pal.setPalletBlocks(segment.getElement(3));
             }
         }
-        return sn1;
+        return pal;
     }
 
-    private SN1ItemDetailParser() {
+    private PALPalletTypeParser() {
         // you can't make me
     }
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/parser/PO4ItemPhysicalDetailParser.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/parser/PO4ItemPhysicalDetailParser.java
@@ -13,34 +13,37 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;
-import com.walmartlabs.x12.asn856.segment.SN1ItemDetail;
-import com.walmartlabs.x12.util.ConversionUtil;
+import com.walmartlabs.x12.asn856.segment.PO4ItemPhysicalDetail;
 
-public class SN1ItemDetailParser {
+public final class PO4ItemPhysicalDetailParser {
 
     /**
      * parse the segment
      * @param segment
      * @return
      */
-    public static SN1ItemDetail parse(X12Segment segment) {
-        SN1ItemDetail sn1 = null;
+    public static PO4ItemPhysicalDetail parse(X12Segment segment) {
+        PO4ItemPhysicalDetail po4 = null;
 
         if (segment != null) {
             String segmentIdentifier = segment.getIdentifier();
-            if (SN1ItemDetail.IDENTIFIER.equals(segmentIdentifier)) {
-                sn1 = new SN1ItemDetail();
-                sn1.setNumberOfUnits(ConversionUtil.convertStringToBigDecimal(segment.getElement(2), 6));
-                sn1.setUnitOfMeasurement(segment.getElement(3));
+            if (PO4ItemPhysicalDetail.IDENTIFIER.equals(segmentIdentifier)) {
+                po4 = new PO4ItemPhysicalDetail();
+                po4.setLength(segment.getElement(10));
+                po4.setWidth(segment.getElement(11));
+                po4.setHeight(segment.getElement(12));
+                po4.setUnitOfMeasurement(segment.getElement(13));
+                po4.setAssignedIdentification(segment.getElement(16));
             }
         }
-        return sn1;
+        return po4;
     }
 
-    private SN1ItemDetailParser() {
+    private PO4ItemPhysicalDetailParser() {
         // you can't make me
     }
 }

--- a/src/main/java/com/walmartlabs/x12/asn856/segment/parser/SN1ItemDetailParser.java
+++ b/src/main/java/com/walmartlabs/x12/asn856/segment/parser/SN1ItemDetailParser.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/main/java/com/walmartlabs/x12/common/segment/DTMDateTimeReference.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/DTMDateTimeReference.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/DTMDateTimeReference.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/DTMDateTimeReference.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/FOBRelatedInstructions.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/FOBRelatedInstructions.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/FOBRelatedInstructions.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/FOBRelatedInstructions.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/LINItemIdentification.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/LINItemIdentification.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/LINItemIdentification.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/LINItemIdentification.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/PIDProductIdentification.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/PIDProductIdentification.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/PIDProductIdentification.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/PIDProductIdentification.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/PKGPackaging.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/PKGPackaging.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/PKGPackaging.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/PKGPackaging.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/REFReferenceInformation.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/REFReferenceInformation.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/common/segment/REFReferenceInformation.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/REFReferenceInformation.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment;
 
 /**

--- a/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.SegmentIterator;

--- a/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12Rule.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.SegmentIterator;

--- a/src/main/java/com/walmartlabs/x12/rule/UniqueDocumentX12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/UniqueDocumentX12Rule.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.SegmentIterator;

--- a/src/main/java/com/walmartlabs/x12/rule/UniqueDocumentX12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/UniqueDocumentX12Rule.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.SegmentIterator;

--- a/src/main/java/com/walmartlabs/x12/rule/X12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/X12Rule.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/main/java/com/walmartlabs/x12/rule/X12Rule.java
+++ b/src/main/java/com/walmartlabs/x12/rule/X12Rule.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/main/java/com/walmartlabs/x12/standard/StandardX12Parser.java
+++ b/src/main/java/com/walmartlabs/x12/standard/StandardX12Parser.java
@@ -213,7 +213,7 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
                         // we are already in a transaction
                         // and have not encountered the end
                         // so we will stop parsing
-                        handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
+                        this.handleUnexpectedSegment(X12TransactionSet.TRANSACTION_SET_TRAILER, currentSegment.getIdentifier());
                     } else {
                         insideTransaction = true;
                         transactionSet.add(currentSegment);
@@ -307,7 +307,7 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
 
             x12Doc.setInterchangeControlEnvelope(isa);
         } else {
-            handleUnexpectedSegment(ENVELOPE_HEADER_ID, segmentIdentifier);
+            this.handleUnexpectedSegment(ENVELOPE_HEADER_ID, segmentIdentifier);
         }
     }
 
@@ -326,7 +326,7 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
             isa.setNumberOfGroups(ConversionUtil.convertStringToInteger(segment.getElement(1)));
             isa.setTrailerInterchangeControlNumber(segment.getElement(2));
         } else {
-            handleUnexpectedSegment(ENVELOPE_TRAILER_ID, segmentIdentifier);
+            this.handleUnexpectedSegment(ENVELOPE_TRAILER_ID, segmentIdentifier);
         }
     }
 
@@ -352,7 +352,7 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
             groupHeader.setResponsibleAgencyCode(segment.getElement(7));
             groupHeader.setVersion(segment.getElement(8));
         } else {
-            handleUnexpectedSegment(GROUP_HEADER_ID, segmentIdentifier);
+            this.handleUnexpectedSegment(GROUP_HEADER_ID, segmentIdentifier);
         }
         return groupHeader;
     }
@@ -370,7 +370,7 @@ public final class StandardX12Parser implements X12Parser<StandardX12Document> {
             x12Group.setNumberOfTransactions(ConversionUtil.convertStringToInteger(segment.getElement(1)));
             x12Group.setTrailerGroupControlNumber(segment.getElement(2));
         } else {
-            handleUnexpectedSegment(GROUP_TRAILER_ID, segmentIdentifier);
+            this.handleUnexpectedSegment(GROUP_TRAILER_ID, segmentIdentifier);
         }
     }
     

--- a/src/main/java/com/walmartlabs/x12/standard/X12ParsedLoop.java
+++ b/src/main/java/com/walmartlabs/x12/standard/X12ParsedLoop.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.standard;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/main/java/com/walmartlabs/x12/standard/X12ParsedLoop.java
+++ b/src/main/java/com/walmartlabs/x12/standard/X12ParsedLoop.java
@@ -1,4 +1,21 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.standard;
+
+import com.walmartlabs.x12.X12Segment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +30,15 @@ public abstract class X12ParsedLoop extends X12Loop {
     // (see Tare in ASN 856 for example)
     private List<X12Loop> parsedChildrenLoops;
     
+    // all the segments associated with the loop
+    // should be parsed as attributes on the subclass
+    // of the X12ParsedLoop
+    // any unexpected segments will be added to
+    // this list
+    // (the MAN segment would be parsed on the Tare
+    // but the PO4 would be unexpected & unparsed)
+    private List<X12Segment> unparsedSegments;
+    
     /**
      * helper method to copy the attributes
      * from the unparsed loop to this object
@@ -23,6 +49,17 @@ public abstract class X12ParsedLoop extends X12Loop {
         this.setHierarchicalId(loop.getHierarchicalId());
         this.setParentHierarchicalId(loop.getParentHierarchicalId());
         this.setSegments(loop.getSegments());
+    }
+    
+    /**
+     * helper method to add {@link X12Segment} to list
+     * @param segment
+     */
+    public void addUnparsedSegment(X12Segment segment) {
+        if (unparsedSegments == null) {
+            unparsedSegments = new ArrayList<>();
+        }
+        unparsedSegments.add(segment);
     }
     
     /**
@@ -42,6 +79,14 @@ public abstract class X12ParsedLoop extends X12Loop {
 
     public void setParsedChildrenLoops(List<X12Loop> parsedChildrenLoops) {
         this.parsedChildrenLoops = parsedChildrenLoops;
+    }
+
+    public List<X12Segment> getUnparsedSegments() {
+        return unparsedSegments;
+    }
+
+    public void setUnparsedSegments(List<X12Segment> unparsedSegments) {
+        this.unparsedSegments = unparsedSegments;
     }
 
 }

--- a/src/main/java/com/walmartlabs/x12/util/SourceToSegmentUtil.java
+++ b/src/main/java/com/walmartlabs/x12/util/SourceToSegmentUtil.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.util;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/main/java/com/walmartlabs/x12/util/SourceToSegmentUtil.java
+++ b/src/main/java/com/walmartlabs/x12/util/SourceToSegmentUtil.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.util;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/main/java/com/walmartlabs/x12/util/TriConsumer.java
+++ b/src/main/java/com/walmartlabs/x12/util/TriConsumer.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.util;
 
 @FunctionalInterface

--- a/src/main/java/com/walmartlabs/x12/util/TriConsumer.java
+++ b/src/main/java/com/walmartlabs/x12/util/TriConsumer.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.util;
 
 @FunctionalInterface

--- a/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserEntireTxSetTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserEntireTxSetTest.java
@@ -262,7 +262,8 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
         assertEquals("P", itemChildLoop.getCode());
 
         Pack pack = (Pack) itemChildLoop;
-        MANMarkNumber man = pack.getMan();
+        List<MANMarkNumber> manList = pack.getManList();
+        MANMarkNumber man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
         assertEquals("10081131916931", man.getNumber());
@@ -276,7 +277,8 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
         assertEquals("P", itemChildLoop.getCode());
 
         pack = (Pack) itemChildLoop;
-        man = pack.getMan();
+        manList = pack.getManList();
+        man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
         assertEquals("10081131916932", man.getNumber());
@@ -333,7 +335,8 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
         assertEquals("T", orderChildLoop.getCode());
 
         Tare tare = (Tare) orderChildLoop;
-        MANMarkNumber man = tare.getMan();
+        List<MANMarkNumber> manList = tare.getManList();
+        MANMarkNumber man = manList.get(0);
         assertNotNull(man);
         assertEquals("GM", man.getQualifier());
         assertEquals("00100700302232310393", man.getNumber());
@@ -351,7 +354,8 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
         assertEquals("P", tareChildLoop.getCode());
 
         Pack pack = (Pack) tareChildLoop;
-        man = pack.getMan();
+        manList = pack.getManList();
+        man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
         assertEquals("10081131916933", man.getNumber());
@@ -438,7 +442,8 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
         assertEquals("P", tareChildLoop.getCode());
 
         pack = (Pack) tareChildLoop;
-        man = pack.getMan();
+        manList = pack.getManList();
+        man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
         assertEquals("10081131916934", man.getNumber());

--- a/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserEntireTxSetTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserEntireTxSetTest.java
@@ -263,6 +263,9 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
 
         Pack pack = (Pack) itemChildLoop;
         List<MANMarkNumber> manList = pack.getManList();
+        assertNotNull(manList);
+        assertEquals(1, manList.size());
+        
         MANMarkNumber man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
@@ -278,6 +281,9 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
 
         pack = (Pack) itemChildLoop;
         manList = pack.getManList();
+        assertNotNull(manList);
+        assertEquals(1, manList.size());
+        
         man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
@@ -336,10 +342,18 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
 
         Tare tare = (Tare) orderChildLoop;
         List<MANMarkNumber> manList = tare.getManList();
+        assertNotNull(manList);
+        assertEquals(2, manList.size());
+        
         MANMarkNumber man = manList.get(0);
         assertNotNull(man);
         assertEquals("GM", man.getQualifier());
         assertEquals("00100700302232310393", man.getNumber());
+        
+        man = manList.get(1);
+        assertNotNull(man);
+        assertEquals("CP", man.getQualifier());
+        assertEquals("11211811413", man.getNumber());
 
         List<X12Loop> tareChildLoops = tare.getParsedChildrenLoops();
         assertNotNull(tareChildLoops);
@@ -355,10 +369,18 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
 
         Pack pack = (Pack) tareChildLoop;
         manList = pack.getManList();
+        assertNotNull(manList);
+        assertEquals(2, manList.size());
+        
         man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
         assertEquals("10081131916933", man.getNumber());
+        
+        man = manList.get(1);
+        assertNotNull(man);
+        assertEquals("CP", man.getQualifier());
+        assertEquals("09970020805822", man.getNumber());
 
         List<X12Loop> packChildLoops = pack.getParsedChildrenLoops();
         assertNotNull(packChildLoops);
@@ -443,6 +465,9 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
 
         pack = (Pack) tareChildLoop;
         manList = pack.getManList();
+        assertNotNull(manList);
+        assertEquals(1, manList.size());
+        
         man = manList.get(0);
         assertNotNull(man);
         assertEquals("UC", man.getQualifier());
@@ -542,10 +567,12 @@ public class DefaultAsn856TransactionSetParserEntireTxSetTest {
         // Tare on Order 2
         txSegments.add(new X12Segment("HL*7*6*T"));
         txSegments.add(new X12Segment("MAN*GM*00100700302232310393"));
+        txSegments.add(new X12Segment("MAN*CP*11211811413"));
 
         // Pack 3 on Tare
         txSegments.add(new X12Segment("HL*8*7*P"));
         txSegments.add(new X12Segment("MAN*UC*10081131916933"));
+        txSegments.add(new X12Segment("MAN*CP*09970020805822"));
 
         // Item on Pack 3
         txSegments.add(new X12Segment("HL*9*8*I"));

--- a/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserPerishableTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserPerishableTest.java
@@ -28,6 +28,7 @@ import com.walmartlabs.x12.common.segment.N1PartyIdentification;
 import com.walmartlabs.x12.common.segment.N3PartyLocation;
 import com.walmartlabs.x12.common.segment.N4GeographicLocation;
 import com.walmartlabs.x12.common.segment.PIDProductIdentification;
+import com.walmartlabs.x12.common.segment.PKGPackaging;
 import com.walmartlabs.x12.common.segment.REFReferenceInformation;
 import com.walmartlabs.x12.common.segment.TD1CarrierDetail;
 import com.walmartlabs.x12.common.segment.TD3CarrierDetail;
@@ -232,17 +233,19 @@ public class DefaultAsn856TransactionSetParserPerishableTest {
         
         Tare tare = (Tare) orderChildLoop;
         
-        MANMarkNumber man = tare.getMan();
+        List<MANMarkNumber> manList = tare.getManList();
+        MANMarkNumber man = manList.get(0);
         assertNotNull(man);
         assertEquals("GM", man.getQualifier());
         assertEquals("00000006510095090366", man.getNumber());
         
-        //        PKGPackaging pkg = tare.getPkg();
-        //        assertNotNull(pkg);
-        //        assertEquals("S", pkg.getItemDescriptionType());
-        //        assertEquals("68", pkg.getPackagingCharacteristicCode());
-        //        assertEquals("FD", pkg.getItemDescriptionType());
-        //        assertEquals("37", pkg.getPackagingDescriptionCode());
+        List<PKGPackaging> pkgList = tare.getPkgList();
+        PKGPackaging pkg = pkgList.get(0);
+        assertNotNull(pkg);
+        assertEquals("S", pkg.getItemDescriptionType());
+        assertEquals("68", pkg.getPackagingCharacteristicCode());
+        assertEquals("FD", pkg.getAgencyQualifierCode());
+        assertEquals("37", pkg.getPackagingDescriptionCode());
 
         List<X12Loop> tareChildLoops = tare.getParsedChildrenLoops();
         assertNotNull(tareChildLoops);

--- a/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/DefaultAsn856TransactionSetParserTest.java
@@ -18,9 +18,11 @@ package com.walmartlabs.x12.asn856;
 
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.X12TransactionSet;
+import com.walmartlabs.x12.asn856.segment.MANMarkNumber;
 import com.walmartlabs.x12.common.segment.DTMDateTimeReference;
 import com.walmartlabs.x12.exceptions.X12ParserException;
 import com.walmartlabs.x12.standard.X12Group;
+import com.walmartlabs.x12.standard.X12Loop;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,7 +30,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DefaultAsn856TransactionSetParserTest {
 
@@ -58,9 +65,7 @@ public class DefaultAsn856TransactionSetParserTest {
     @Test
     public void test_handlesTransactionSet_OnlyEnvelope() {
         X12Group x12Group = new X12Group();
-        List<X12Segment> segments = this.getTestSegments();
-        segments.remove(2); // remove HL(S)
-        segments.remove(1); // remove BSN
+        List<X12Segment> segments = this.getEnvelopeOnly();
         assertTrue(txParser.handlesTransactionSet(segments, x12Group));
     }
     
@@ -167,6 +172,44 @@ public class DefaultAsn856TransactionSetParserTest {
         assertEquals("05755986", asnTx.getShipmentIdentification());
         List<DTMDateTimeReference> dtms = asnTx.getDtmReferences();
         assertNull(dtms);
+        
+        // shipment
+        Shipment shipment = asnTx.getShipment();
+        List<X12Loop> orders = shipment.getParsedChildrenLoops();
+        assertNotNull(orders);
+        assertEquals(1, orders.size());
+        
+        // order
+        X12Loop orderLoop = orders.get(0);
+        assertNotNull(orderLoop);
+        assertTrue(orderLoop instanceof Order);
+        assertEquals("O", orderLoop.getCode());
+
+        List<X12Loop> tares = ((Order)orderLoop).getParsedChildrenLoops();
+        assertNotNull(tares);
+        assertEquals(1, tares.size());
+
+        // tare
+        X12Loop tareLoop = tares.get(0);
+        assertNotNull(tareLoop);
+        assertTrue(tareLoop instanceof Tare);
+        assertEquals("T", tareLoop.getCode());
+
+        Tare tare = (Tare) tareLoop;
+        List<MANMarkNumber> manList = tare.getManList();
+        MANMarkNumber man = manList.get(0);
+        assertNotNull(man);
+        assertEquals("GM", man.getQualifier());
+        assertEquals("00100700302232310393", man.getNumber());
+        
+        List<X12Segment> unparsedSegments = tare.getUnparsedSegments();
+        assertNotNull(unparsedSegments);
+        assertEquals(1, unparsedSegments.size());
+        assertEquals("TEST", unparsedSegments.get(0).getElement(2));
+
+        List<X12Loop> tareChildLoops = tare.getParsedChildrenLoops();
+        assertNotNull(tareChildLoops);
+        assertEquals(1, tareChildLoops.size());
     }
     
     private List<X12Segment> getSegmentsOnlyEnvelope() {
@@ -225,16 +268,54 @@ public class DefaultAsn856TransactionSetParserTest {
         
         return txSegments;
     }
-    
-    private List<X12Segment> getTestSegments() {
+
+    private List<X12Segment> getEnvelopeOnly() {
         List<X12Segment> txSegments = new ArrayList<>();
-        
+
         txSegments.add(new X12Segment("ST*856*368090001"));
-        txSegments.add(new X12Segment("BSN*00*05755986*20190523*171543*0002"));
-        txSegments.add(new X12Segment("HL*1**S"));
         txSegments.add(new X12Segment("SE*296*368090001"));
-        
+
         return txSegments;
     }
-    
+
+    private List<X12Segment> getTestSegments() {
+        List<X12Segment> txSegments = new ArrayList<>();
+
+        //
+        // ASN 856
+        txSegments.add(new X12Segment("ST*856*368090001"));
+        txSegments.add(new X12Segment("BSN*00*05755986*20190523*171543*0002"));
+
+        //
+        // shipment
+        //
+        txSegments.add(new X12Segment("HL*1**S"));
+
+        //
+        // order
+        //
+        txSegments.add(new X12Segment("HL*2*1*O"));
+
+        // Tare
+        txSegments.add(new X12Segment("HL*3*2*T"));
+        txSegments.add(new X12Segment("MAN*GM*00100700302232310393"));
+        txSegments.add(new X12Segment("REF*XX*TEST"));
+
+        // Pack
+        txSegments.add(new X12Segment("HL*4*3*P"));
+        txSegments.add(new X12Segment("MAN*UC*10081131916933"));
+
+        // Item
+        txSegments.add(new X12Segment("HL*5*4*I"));
+        txSegments.add(new X12Segment("LIN**UP*039364170623"));
+        txSegments.add(new X12Segment("SN1**18*EA"));
+
+        //
+        // SE
+        //
+        txSegments.add(new X12Segment("SE*296*368090001"));
+
+        return txSegments;
+    }
+
 }

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/MANMarkNumberParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/MANMarkNumberParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PALPalletTypeParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PALPalletTypeParserTest.java
@@ -16,36 +16,33 @@ limitations under the License.
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;
-import com.walmartlabs.x12.asn856.segment.MANMarkNumber;
+import com.walmartlabs.x12.asn856.segment.PALPalletType;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
-public class MANMarkNumberParserTest {
-
+public class PALPalletTypeParserTest {
 
     @Test
     public void test_parse_null_segment() {
         X12Segment segment = null;
-        MANMarkNumber man = MANMarkNumberParser.parse(segment);
-        assertNull(man);
+        PALPalletType pal = PALPalletTypeParser.parse(segment);
+        assertNull(pal);
     }
 
     @Test
     public void test_parse_empty_segment() {
         X12Segment segment = new X12Segment("");
-        MANMarkNumber man = MANMarkNumberParser.parse(segment);
-        assertNull(man);
+        PALPalletType pal = PALPalletTypeParser.parse(segment);
+        assertNull(pal);
     }
 
     @Test
     public void test_parse_segment() {
-        X12Segment segment = new X12Segment("MAN*UC*10081131916931");
-        MANMarkNumber man = MANMarkNumberParser.parse(segment);
-        assertNotNull(man);
-        assertEquals("UC", man.getQualifier());
-        assertEquals("10081131916931", man.getNumber());
+        X12Segment segment = new X12Segment("PAL**6*5");
+        PALPalletType pal = PALPalletTypeParser.parse(segment);
+        assertNotNull(pal);
+        assertEquals("6", pal.getPalletTiers());
+        assertEquals("5", pal.getPalletBlocks());
     }
 }

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PALPalletTypeParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PALPalletTypeParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PO4ItemPhysicalDetailParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PO4ItemPhysicalDetailParserTest.java
@@ -1,0 +1,65 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package com.walmartlabs.x12.asn856.segment.parser;
+
+import com.walmartlabs.x12.X12Segment;
+import com.walmartlabs.x12.asn856.segment.PO4ItemPhysicalDetail;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class PO4ItemPhysicalDetailParserTest {
+
+    @Test
+    public void test_parse_null_segment() {
+        X12Segment segment = null;
+        PO4ItemPhysicalDetail po4 = PO4ItemPhysicalDetailParser.parse(segment);
+        assertNull(po4);
+    }
+
+    @Test
+    public void test_parse_empty_segment() {
+        X12Segment segment = new X12Segment("");
+        PO4ItemPhysicalDetail po4 = PO4ItemPhysicalDetailParser.parse(segment);
+        assertNull(po4);
+    }
+
+    @Test
+    public void test_parse_segment_dimensions() {
+        X12Segment segment = new X12Segment("PO4**********60*40*17.2*CM");
+        PO4ItemPhysicalDetail po4 = PO4ItemPhysicalDetailParser.parse(segment);
+        assertNotNull(po4);
+        assertEquals("60", po4.getLength());
+        assertEquals("40", po4.getWidth());
+        assertEquals("17.2", po4.getHeight());
+        assertEquals("CM", po4.getUnitOfMeasurement());
+        assertNull(po4.getAssignedIdentification());
+    }
+    
+    @Test
+    public void test_parse_segment_standard() {
+        X12Segment segment = new X12Segment("PO4****************RPC6413");
+        PO4ItemPhysicalDetail po4 = PO4ItemPhysicalDetailParser.parse(segment);
+        assertNotNull(po4);
+        assertNull(po4.getLength());
+        assertNull(po4.getWidth());
+        assertNull(po4.getHeight());
+        assertNull(po4.getUnitOfMeasurement());
+        assertEquals("RPC6413", po4.getAssignedIdentification());
+    }
+}

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PO4ItemPhysicalDetailParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PO4ItemPhysicalDetailParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PRFPurchaseOrderReferenceParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PRFPurchaseOrderReferenceParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PRFPurchaseOrderReferenceParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/PRFPurchaseOrderReferenceParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/SN1ItemDetailParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/SN1ItemDetailParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/asn856/segment/parser/SN1ItemDetailParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/asn856/segment/parser/SN1ItemDetailParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.asn856.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/DTMDateTimeReferenceParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/DTMDateTimeReferenceParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/DTMDateTimeReferenceParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/DTMDateTimeReferenceParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/FOBRelatedInstructionsParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/FOBRelatedInstructionsParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/FOBRelatedInstructionsParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/FOBRelatedInstructionsParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/LINItemIdentificationParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/LINItemIdentificationParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/LINItemIdentificationParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/LINItemIdentificationParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/PIDPartyIdentificationParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/PIDPartyIdentificationParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/PIDPartyIdentificationParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/PIDPartyIdentificationParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/PKGPackagingParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/PKGPackagingParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/PKGPackagingParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/PKGPackagingParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParserTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParserTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/TD1CarrierDetailParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/TD1CarrierDetailParserTest.java
@@ -18,9 +18,7 @@ package com.walmartlabs.x12.common.segment.parser;
 
 import com.walmartlabs.x12.X12Segment;
 import com.walmartlabs.x12.common.segment.TD1CarrierDetail;
-import com.walmartlabs.x12.common.segment.parser.TD1CarrierDetailParser;
 import com.walmartlabs.x12.exceptions.X12ParserException;
-import com.walmartlabs.x12.types.UnitMeasure;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
+++ b/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
+++ b/src/test/java/com/walmartlabs/x12/rule/TrailerSegmentCountX12RuleTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/rule/UniqueDocumentX12RuleTest.java
+++ b/src/test/java/com/walmartlabs/x12/rule/UniqueDocumentX12RuleTest.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/rule/UniqueDocumentX12RuleTest.java
+++ b/src/test/java/com/walmartlabs/x12/rule/UniqueDocumentX12RuleTest.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.rule;
 
 import com.walmartlabs.x12.X12Segment;

--- a/src/test/java/com/walmartlabs/x12/standard/AssertBaseDocumentUtil.java
+++ b/src/test/java/com/walmartlabs/x12/standard/AssertBaseDocumentUtil.java
@@ -1,3 +1,18 @@
+/**
+Copyright (c) 2018-present, Walmart, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package com.walmartlabs.x12.standard;
 
 import com.walmartlabs.x12.X12TransactionSet;

--- a/src/test/java/com/walmartlabs/x12/standard/AssertBaseDocumentUtil.java
+++ b/src/test/java/com/walmartlabs/x12/standard/AssertBaseDocumentUtil.java
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
+
 package com.walmartlabs.x12.standard;
 
 import com.walmartlabs.x12.X12TransactionSet;


### PR DESCRIPTION
This PR will start to break backward compatibility as some ASN objects can support more than 1 segment for various types and we had originally had it modeled as a single entry.

**Order**
- added TD1 segment

**Tare**
- updated PKG segment to a List
- added PAL segment
- updated MAN segment to a List

**Pack**
- updated MAN segment to a List
- added N1 segment
- added PO4 segment

**Item**
- added DTM segment list
- added REF segment list

The `X12ParsedLoop` has a new attribute - a list of `unparsedSegments`
When an unexpected segment is encountered on a Loop it will be added to this list. 

An example:
```
    private void doTareSegments(X12Segment segment, SegmentIterator segmentIterator, Tare tare) {
        switch (segment.getIdentifier()) {
            case PKGPackaging.IDENTIFIER:
                tare.addPKGPackaging(PKGPackagingParser.parse(segment));
                break;       
            case PALPalletType.IDENTIFIER:
                tare.setPal(PALPalletTypeParser.parse(segment));
                break;
            case MANMarkNumber.IDENTIFIER:
                tare.addMANMarkNumber(MANMarkNumberParser.parse(segment));
                break;                
            default:
                tare.addUnparsedSegment(segment);
                break;
        }
    }
 ```

Added missing license header comment to various files