### PR TITLE
make loop error methods accessible via interface

### DIFF
--- a/src/main/java/com/walmartlabs/x12/AbstractX12TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/AbstractX12TransactionSet.java
@@ -24,6 +24,7 @@ package com.walmartlabs.x12;
  *
  */
 public abstract class AbstractX12TransactionSet implements X12TransactionSet {
+    
     /*
      * ST
      */

--- a/src/main/java/com/walmartlabs/x12/X12TransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/X12TransactionSet.java
@@ -16,6 +16,11 @@ limitations under the License.
 
 package com.walmartlabs.x12;
 
+import com.walmartlabs.x12.exceptions.X12ErrorDetail;
+
+import java.util.Collections;
+import java.util.List;
+
 /**
  * 
  * Implementations should store the common ST/SE elements 
@@ -24,62 +29,91 @@ package com.walmartlabs.x12;
  *
  */
 public interface X12TransactionSet {
-    
+
     public static final String TRANSACTION_SET_HEADER = "ST";
     public static final String TRANSACTION_SET_TRAILER = "SE";
     public static final String TRANSACTION_ITEM_TOTAL = "CTT";
     public static final String TRANSACTION_AMOUNT_TOTAL = "AMT";
-    
+
     /**
-     * The ST01 segment element contains the functional group code, which 
-     * identifies the X12 transaction type 
+     * The ST01 segment element contains the functional group code, which identifies
+     * the X12 transaction type
      * 
-     * common X12 transaction types associated with retail are 856 (ASN), 
-     * 850 (PO), and 812 (invoice). 
+     * common X12 transaction types associated with retail are 856 (ASN), 850 (PO),
+     * and 812 (invoice).
      * 
-     * @return the ST01 segment value 
+     * @return the ST01 segment value
      */
     String getTransactionSetIdentifierCode();
-    
+
     void setTransactionSetIdentifierCode(String transactionSetIdentifierCode);
 
     /**
-     * The ST02 segment element contains the control number. This should match
-     * the control number on the corresponding transaction trailer segment.
+     * The ST02 segment element contains the control number. This should match the
+     * control number on the corresponding transaction trailer segment.
      * 
-     * @return the ST02 segment value 
+     * @return the ST02 segment value
      */
-    String getHeaderControlNumber() ;
-    
+    String getHeaderControlNumber();
+
     void setHeaderControlNumber(String headerControlNumber);
 
     /**
-     * The SE01 segment element contains the number of segments that 
-     * are in this transaction.
+     * The SE01 segment element contains the number of segments that are in this
+     * transaction.
      * 
-     * @return the SE01 segment value 
+     * @return the SE01 segment value
      */
     Integer getExpectedNumberOfSegments();
-    
+
     void setExpectedNumberOfSegments(Integer expectedNumberOfSegments);
 
     /**
-     * The SE02 segment element contains the control number. This should match
-     * the control number on the corresponding transaction header segment.
+     * The SE02 segment element contains the control number. This should match the
+     * control number on the corresponding transaction header segment.
      * 
-     * @return the SE02 segment value 
+     * @return the SE02 segment value
      */
     String getTrailerControlNumber();
-    
+
     void setTrailerControlNumber(String trailerControlNumber);
-    
+
     /**
-     * The CTT01 segment element contains the transaction count. 
-     * This is an optional segment lien
+     * The CTT01 segment element contains the transaction count. This is an optional
+     * segment lien
      * 
-     * @return the CTT01 segment value 
+     * @return the CTT01 segment value
      */
     Integer getTransactionLineItems();
 
     void setTransactionLineItems(Integer transactionLineItems);
+
+    /**
+     * any looping errors will be stored in this list 
+     * 
+     * possible errors include
+     * orphan loops and those without proper indexing
+     * 
+     * @return list of {@link X12ErrorDetail}
+     */
+    default List<X12ErrorDetail> getLoopingErrors() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * check to determine if loop parsing was valid
+     * @return true if there are looping errors otherwise false
+     */
+    default boolean isLoopingValid() {
+        return false;
+    }
+
+    /**
+     * check to see if the transaction set supports looping
+     * 
+     * @return true if this type of transaction set supports loops otherwise false
+     */
+    default boolean hasLooping() {
+        return false;
+    }
 }

--- a/src/main/java/com/walmartlabs/x12/standard/txset/asn856/AsnTransactionSet.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/asn856/AsnTransactionSet.java
@@ -24,6 +24,7 @@ import com.walmartlabs.x12.standard.txset.asn856.loop.Shipment;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class AsnTransactionSet extends AbstractX12TransactionSet {
@@ -65,17 +66,6 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
         }
         dtmReferences.add(dtm);
     }
-
-    /**
-     * helper method to add X12ErrorDetail for looping errors
-     * @param errorDetail
-     */
-    public void addX12ErrorDetailForLoop(X12ErrorDetail errorDetail) {
-        if (CollectionUtils.isEmpty(loopingErrors)) {
-            loopingErrors = new ArrayList<>();
-        }
-        loopingErrors.add(errorDetail);
-    }
     
     /**
      * helper method to add unexpected segments to list
@@ -88,7 +78,44 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
         }
         unexpectedSegmentsBeforeLoop.add(segment);
     }
+
+    /**
+     * helper method to add X12ErrorDetail for looping errors
+     * @param errorDetail
+     */
+    public void addX12ErrorDetailForLoop(X12ErrorDetail errorDetail) {
+        this.addX12ErrorDetailForLoop(Collections.singletonList(errorDetail));
+    }
     
+    /**
+     * helper method to add multiple X12ErrorDetail for looping errors
+     * @param errorDetail
+     */
+    public void addX12ErrorDetailForLoop(List<X12ErrorDetail> errorDetails) {
+        if (!CollectionUtils.isEmpty(errorDetails)) {
+            if (CollectionUtils.isEmpty(loopingErrors)) {
+                loopingErrors = new ArrayList<>();
+            }
+            loopingErrors.addAll(errorDetails);
+            loopingValid = false;
+        }
+    }
+
+    @Override
+    public boolean hasLooping() {
+        return true;
+    }
+    
+    @Override
+    public boolean isLoopingValid() {
+        return loopingValid;
+    }
+
+    @Override
+    public List<X12ErrorDetail> getLoopingErrors() {
+        return loopingErrors;
+    }
+
     public String getPurposeCode() {
         return purposeCode;
     }
@@ -151,22 +178,6 @@ public class AsnTransactionSet extends AbstractX12TransactionSet {
 
     public void setUnexpectedSegmentsBeforeLoop(List<X12Segment> unexpectedSegmentsBeforeLoop) {
         this.unexpectedSegmentsBeforeLoop = unexpectedSegmentsBeforeLoop;
-    }
-
-    public boolean isLoopingValid() {
-        return loopingValid;
-    }
-
-    public void setLoopingValid(boolean loopingValid) {
-        this.loopingValid = loopingValid;
-    }
-
-    public List<X12ErrorDetail> getLoopingErrors() {
-        return loopingErrors;
-    }
-
-    public void setLoopingErrors(List<X12ErrorDetail> loopingErrors) {
-        this.loopingErrors = loopingErrors;
     }
     
 }

--- a/src/main/java/com/walmartlabs/x12/standard/txset/asn856/DefaultAsn856TransactionSetParser.java
+++ b/src/main/java/com/walmartlabs/x12/standard/txset/asn856/DefaultAsn856TransactionSetParser.java
@@ -209,7 +209,6 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
                 });
             }
         } else {
-            asnTx.setLoopingValid(false);
             asnTx.addX12ErrorDetailForLoop(
                 new X12ErrorDetail("HL", "03", "first HL is not a shipment it was " + unparsedLoop.getCode()));
         }
@@ -243,7 +242,6 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
             this.parseEachChildrenLoop(unparsedLoop, order);
 
         } else {
-            asnTx.setLoopingValid(false);
             asnTx.addX12ErrorDetailForLoop(
                 new X12ErrorDetail("HL", "03", "expected Order HL but got " + unparsedLoop.getCode()));
         }
@@ -654,8 +652,7 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
 
                 // add loop errors to tx (if any)
                 List<X12ErrorDetail> loopErrors = loopHolder.getLoopErrors();
-                asnTx.setLoopingValid(CollectionUtils.isEmpty(loopErrors));
-                asnTx.setLoopingErrors(loopHolder.getLoopErrors());
+                asnTx.addX12ErrorDetailForLoop(loopErrors);
                 
                 // handle loops
                 List<X12Loop> loops = loopHolder.getLoops();
@@ -668,7 +665,6 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
                 segments.reset(indexToSegmentAfterHierarchicalLoops);
             } else {
                 // doesn't start w/ HL
-                asnTx.setLoopingValid(false);
                 asnTx.addX12ErrorDetailForLoop(
                     new X12ErrorDetail(currentSegment.getIdentifier(), null, "missing shipment loop"));
                 // we should back it up
@@ -716,7 +712,6 @@ public class DefaultAsn856TransactionSetParser extends AbstractTransactionSetPar
             X12Loop firstLoop = loops.get(0);
             this.parseShipmentLoop(firstLoop, asnTx);
         } else {
-            asnTx.setLoopingValid(false);
             asnTx.addX12ErrorDetailForLoop(new X12ErrorDetail("HL", null, "expected one top level HL"));
         }
     }


### PR DESCRIPTION
The access to looping errors via `isLoopingValid` and `getLoopingErrors` were originally added to the `AsnTransactionSet`

To make these accessible via any transaction set and insure common naming on new transaction sets these methods were added to the `X12TransactionSet` interface with a new method `hasLooping`