### PR TITLE
BUG FIX: generic error text and add value for specifics

### DIFF
--- a/src/main/java/com/walmartlabs/x12/exceptions/X12ErrorDetail.java
+++ b/src/main/java/com/walmartlabs/x12/exceptions/X12ErrorDetail.java
@@ -19,20 +19,22 @@ package com.walmartlabs.x12.exceptions;
 public class X12ErrorDetail {
     private String segmentId;
     private String elementId;
-    private Integer lineNumber;
-    private String message;
-
-    public X12ErrorDetail(String segmentId, String elementId, String msg) {
+    // can be used as TED 02 error text in 824
+    private String issueText;
+    // can be used as TED 07 invalid value in 824
+    private String invalidValue;
+    
+    public X12ErrorDetail(String segmentId, String elementId, String issueText) {
         this.segmentId = segmentId;
         this.elementId = elementId;
-        this.message = msg;
+        this.issueText = issueText;
     }
 
-    public X12ErrorDetail(String segmentId, String elementId, Integer lineNumber, String msg) {
+    public X12ErrorDetail(String segmentId, String elementId, String issueText, String invalidValue) {
         this.segmentId = segmentId;
         this.elementId = elementId;
-        this.lineNumber = lineNumber;
-        this.message = msg;
+        this.issueText = issueText;
+        this.invalidValue = invalidValue;
     }
 
     public String getSegmentId() {
@@ -43,12 +45,12 @@ public class X12ErrorDetail {
         return elementId;
     }
 
-    public Integer getLineNumber() {
-        return lineNumber;
+    public String getIssueText() {
+        return issueText;
     }
-
-    public String getMessage() {
-        return message;
+    
+    public String getInvalidValue() {
+        return invalidValue;
     }
 
     @Override
@@ -56,8 +58,8 @@ public class X12ErrorDetail {
         StringBuilder sb = new StringBuilder("error:");
         sb.append("\\nsegmentId: ").append(segmentId);
         sb.append("\\nelementId: ").append(elementId);
-        sb.append("\\nline number: ").append(lineNumber);
-        sb.append("\\nmessage: ").append(message);
+        sb.append("\\nissue text: ").append(issueText);
+        sb.append("\\nissue value: ").append(invalidValue);
         return sb.toString();
     }
 }

--- a/src/main/java/com/walmartlabs/x12/exceptions/X12ParserException.java
+++ b/src/main/java/com/walmartlabs/x12/exceptions/X12ParserException.java
@@ -40,7 +40,7 @@ public class X12ParserException extends RuntimeException {
     }
 
     public X12ParserException(X12ErrorDetail error) {
-        super(error != null ? error.getMessage() : "");
+        super(error != null ? error.getIssueText() : "");
         this.errorDetail = error;
     }
 

--- a/src/main/java/com/walmartlabs/x12/util/X12ParsingUtil.java
+++ b/src/main/java/com/walmartlabs/x12/util/X12ParsingUtil.java
@@ -75,7 +75,7 @@ public final class X12ParsingUtil {
         sb.append(expectedSegmentId);
         sb.append(" segment but found ");
         sb.append(actualSegmentId);
-        return new X12ErrorDetail(actualSegmentId, null, sb.toString());
+        return new X12ErrorDetail(actualSegmentId, null, "expected one segment but found another", sb.toString());
     }
 
     /**

--- a/src/main/java/com/walmartlabs/x12/util/loop/X12LoopUtil.java
+++ b/src/main/java/com/walmartlabs/x12/util/loop/X12LoopUtil.java
@@ -28,7 +28,10 @@ import java.util.List;
 import java.util.Map;
 
 public final class X12LoopUtil {
-
+    
+    private static final String MISSING_PARENT_ERROR = "HL segment is missing parent";
+    private static final String ALREADY_EXISTS_ERROR = "HL segment already exists";
+    
     /**
      * check the segment for the start of HL
      * @param segment
@@ -107,12 +110,8 @@ public final class X12LoopUtil {
                 // to be found quickly
                 String loopId = loop.getHierarchicalId();
                 if (loopMap.containsKey(loopId)) {
-                    StringBuilder sb = new StringBuilder();
-                    sb.append("HL segment with id (")
-                        .append(loopId)
-                        .append(") already exists");
-                    loopHolder.addX12ErrorDetail(
-                        new X12ErrorDetail(X12Loop.HIERARCHY_LOOP_ID, null, sb.toString()));
+                    X12ErrorDetail loopError = loopAlreadyExistsErrorDetail(loop);
+                    loopHolder.addX12ErrorDetail(loopError);
                 } else {
                     loopMap.put(loop.getHierarchicalId(), loop);
                 }
@@ -160,13 +159,25 @@ public final class X12LoopUtil {
             if (parentLoop != null) {
                 parentLoop.addLoop(loop);
             } else {
-                StringBuilder sb = new StringBuilder();
-                sb.append("HL segment with id (").append(loop.getHierarchicalId()).append(")");
-                sb.append(" is missing parent (").append(loop.getParentHierarchicalId()).append(")");
-                loopHolder.addX12ErrorDetail(
-                    new X12ErrorDetail(X12Loop.HIERARCHY_LOOP_ID, null, sb.toString()));
+                X12ErrorDetail loopError = loopMissingParentErrorDetail(loop);
+                loopHolder.addX12ErrorDetail(loopError);
             }
         }
+    }
+    
+    private static X12ErrorDetail loopAlreadyExistsErrorDetail(X12Loop loop) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("HL segment with id (")
+            .append(loop.getHierarchicalId())
+            .append(") already exists");
+        return new X12ErrorDetail(X12Loop.HIERARCHY_LOOP_ID, null, ALREADY_EXISTS_ERROR, sb.toString());
+    }
+    
+    private static X12ErrorDetail loopMissingParentErrorDetail(X12Loop loop) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("HL segment with id (").append(loop.getHierarchicalId()).append(")");
+        sb.append(" is missing parent (").append(loop.getParentHierarchicalId()).append(")");
+        return new X12ErrorDetail(X12Loop.HIERARCHY_LOOP_ID, null, MISSING_PARENT_ERROR, sb.toString());
     }
 
     private X12LoopUtil() {

--- a/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ParseValidateTest.java
+++ b/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ParseValidateTest.java
@@ -256,7 +256,7 @@ public class DefaultDex894ParseValidateTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G85", xed.getSegmentId());
         assertEquals("G8501", xed.getElementId());
-        assertEquals("CRC Integrity Check does not match", xed.getMessage());
+        assertEquals("CRC Integrity Check does not match", xed.getIssueText());
     }
 
     @Test

--- a/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ValidatorTest.java
+++ b/src/test/java/com/walmartlabs/x12/dex/dx894/DefaultDex894ValidatorTest.java
@@ -105,18 +105,18 @@ public class DefaultDex894ValidatorTest {
         assertEquals(2, errorSet.size());
 
         List<X12ErrorDetail> list = errorSet.stream()
-            .sorted((o1, o2) -> o1.getMessage().compareTo(o2.getMessage()))
+            .sorted((o1, o2) -> o1.getIssueText().compareTo(o2.getIssueText()))
             .collect(Collectors.toList());
 
         X12ErrorDetail xed = list.get(0);
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8202", xed.getElementId());
-        assertEquals("Duplicate invoice numbers on DEX", xed.getMessage());
+        assertEquals("Duplicate invoice numbers on DEX", xed.getIssueText());
 
         xed = list.get(1);
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8202", xed.getElementId());
-        assertEquals("Missing supplier number", xed.getMessage());
+        assertEquals("Missing supplier number", xed.getIssueText());
     }
 
     @Test
@@ -260,7 +260,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail ed = dexValidator.checkForDuplicateInvoiceNumbers(dex);
         assertNotNull(ed);
         assertEquals("G82", ed.getSegmentId());
-        assertEquals("Duplicate invoice numbers on DEX", ed.getMessage());
+        assertEquals("Duplicate invoice numbers on DEX", ed.getIssueText());
     }
 
     @Test
@@ -349,7 +349,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G85", xed.getSegmentId());
         assertEquals("G8501", xed.getElementId());
-        assertEquals("CRC Integrity Check does not match", xed.getMessage());
+        assertEquals("CRC Integrity Check does not match", xed.getIssueText());
     }
 
     @Test
@@ -364,7 +364,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8202", xed.getElementId());
-        assertEquals("Missing supplier number", xed.getMessage());
+        assertEquals("Missing supplier number", xed.getIssueText());
     }
 
     @Test
@@ -380,7 +380,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail x12ErrorDetail = errors.stream().findFirst().get();
         assertEquals("G82", x12ErrorDetail.getSegmentId());
         assertEquals("G8204", x12ErrorDetail.getElementId());
-        assertEquals("Missing receiver location number", x12ErrorDetail.getMessage());
+        assertEquals("Missing receiver location number", x12ErrorDetail.getIssueText());
     }
 
     @Test
@@ -395,7 +395,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8202", xed.getElementId());
-        assertEquals("Missing supplier number", xed.getMessage());
+        assertEquals("Missing supplier number", xed.getIssueText());
     }
 
     @Test
@@ -410,7 +410,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8202", xed.getElementId());
-        assertEquals("Missing supplier number", xed.getMessage());
+        assertEquals("Missing supplier number", xed.getIssueText());
     }
 
     @Test
@@ -425,7 +425,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8202", xed.getElementId());
-        assertEquals("Missing supplier number", xed.getMessage());
+        assertEquals("Missing supplier number", xed.getIssueText());
     }
 
     @Test
@@ -440,7 +440,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8207", xed.getElementId());
-        assertEquals("Missing supplier date", xed.getMessage());
+        assertEquals("Missing supplier date", xed.getIssueText());
     }
 
     @Test
@@ -455,7 +455,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8207", xed.getElementId());
-        assertEquals("Missing supplier date", xed.getMessage());
+        assertEquals("Missing supplier date", xed.getIssueText());
     }
 
     @Test
@@ -470,7 +470,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8207", xed.getElementId());
-        assertEquals("Missing supplier date", xed.getMessage());
+        assertEquals("Missing supplier date", xed.getIssueText());
     }
 
     @Test
@@ -485,7 +485,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8207", xed.getElementId());
-        assertEquals("Missing supplier date", xed.getMessage());
+        assertEquals("Missing supplier date", xed.getIssueText());
     }
 
     @Test
@@ -500,7 +500,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8207", xed.getElementId());
-        assertEquals("Date must be in YYYYMMDD format", xed.getMessage());
+        assertEquals("Date must be in YYYYMMDD format", xed.getIssueText());
     }
 
     @Test
@@ -515,7 +515,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G82", xed.getSegmentId());
         assertEquals("G8207", xed.getElementId());
-        assertEquals("Date must be in YYYYMMDD format", xed.getMessage());
+        assertEquals("Date must be in YYYYMMDD format", xed.getIssueText());
     }
 
     @Test
@@ -551,7 +551,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8302", xed.getElementId());
-        assertEquals("Missing quantity", xed.getMessage());
+        assertEquals("Missing quantity", xed.getIssueText());
     }
 
     @Test
@@ -567,7 +567,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8302", xed.getElementId());
-        assertEquals("Missing quantity", xed.getMessage());
+        assertEquals("Missing quantity", xed.getIssueText());
     }
 
     @Test
@@ -583,7 +583,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8302", xed.getElementId());
-        assertEquals("Quantity must be positive", xed.getMessage());
+        assertEquals("Quantity must be positive", xed.getIssueText());
     }
 
     @Test
@@ -599,7 +599,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8302", xed.getElementId());
-        assertEquals("Quantity must be positive", xed.getMessage());
+        assertEquals("Quantity must be positive", xed.getIssueText());
     }
 
     @Test
@@ -615,7 +615,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8303", xed.getElementId());
-        assertEquals("Missing/unknown unit of measure", xed.getMessage());
+        assertEquals("Missing/unknown unit of measure", xed.getIssueText());
     }
 
     @Test
@@ -631,7 +631,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8303", xed.getElementId());
-        assertEquals("Missing/unknown unit of measure", xed.getMessage());
+        assertEquals("Missing/unknown unit of measure", xed.getIssueText());
     }
 
     @Test
@@ -647,7 +647,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8303", xed.getElementId());
-        assertEquals("Missing/unknown unit of measure", xed.getMessage());
+        assertEquals("Missing/unknown unit of measure", xed.getIssueText());
     }
 
     @Test
@@ -663,7 +663,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8303", xed.getElementId());
-        assertEquals("Missing/unknown unit of measure", xed.getMessage());
+        assertEquals("Missing/unknown unit of measure", xed.getIssueText());
     }
 
     @Test
@@ -679,7 +679,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8304", xed.getElementId());
-        assertEquals("Missing consumer UPC", xed.getMessage());
+        assertEquals("Missing consumer UPC", xed.getIssueText());
     }
 
     @Test
@@ -695,7 +695,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8304", xed.getElementId());
-        assertEquals("Missing consumer UPC", xed.getMessage());
+        assertEquals("Missing consumer UPC", xed.getIssueText());
     }
 
     @Test
@@ -711,7 +711,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8306", xed.getElementId());
-        assertEquals("Missing consumer UPC", xed.getMessage());
+        assertEquals("Missing consumer UPC", xed.getIssueText());
     }
 
     @Test
@@ -727,7 +727,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8306", xed.getElementId());
-        assertEquals("Missing consumer UPC", xed.getMessage());
+        assertEquals("Missing consumer UPC", xed.getIssueText());
     }
 
     @Test
@@ -743,7 +743,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8305", xed.getElementId());
-        assertEquals("Missing consumer qualifier", xed.getMessage());
+        assertEquals("Missing consumer qualifier", xed.getIssueText());
     }
 
     @Test
@@ -776,7 +776,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8307", xed.getElementId());
-        assertEquals("Missing case UPC", xed.getMessage());
+        assertEquals("Missing case UPC", xed.getIssueText());
     }
 
     @Test
@@ -795,7 +795,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8309", xed.getElementId());
-        assertEquals("Missing case count", xed.getMessage());
+        assertEquals("Missing case count", xed.getIssueText());
     }
 
     @Test
@@ -833,7 +833,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8312", xed.getElementId());
-        assertEquals("Missing case UPC", xed.getMessage());
+        assertEquals("Missing case UPC", xed.getIssueText());
     }
 
     @Test
@@ -856,7 +856,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8311", xed.getElementId());
-        assertEquals("Missing case qualifier", xed.getMessage());
+        assertEquals("Missing case qualifier", xed.getIssueText());
     }
 
     @Test
@@ -879,7 +879,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8309", xed.getElementId());
-        assertEquals("Missing case count", xed.getMessage());
+        assertEquals("Missing case count", xed.getIssueText());
     }
 
     @Test
@@ -902,12 +902,12 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = list.get(0);
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8305", xed.getElementId());
-        assertEquals("Missing consumer qualifier", xed.getMessage());
+        assertEquals("Missing consumer qualifier", xed.getIssueText());
 
         xed = list.get(1);
         assertEquals("G83", xed.getSegmentId());
         assertEquals("G8311", xed.getElementId());
-        assertEquals("Missing case qualifier", xed.getMessage());
+        assertEquals("Missing case qualifier", xed.getIssueText());
     }
 
     @Test
@@ -936,17 +936,17 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = list.get(0);
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7201", xed.getElementId());
-        assertEquals("Missing allowance code", xed.getMessage());
+        assertEquals("Missing allowance code", xed.getIssueText());
 
         xed = list.get(1);
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7202", xed.getElementId());
-        assertEquals("Missing method of handling code", xed.getMessage());
+        assertEquals("Missing method of handling code", xed.getIssueText());
 
         xed = list.get(2);
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7205", xed.getElementId());
-        assertEquals("Must have allowance rate, percent, or amount", xed.getMessage());
+        assertEquals("Must have allowance rate, percent, or amount", xed.getIssueText());
     }
 
     @Test
@@ -966,7 +966,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7201", xed.getElementId());
-        assertEquals("Missing allowance code", xed.getMessage());
+        assertEquals("Missing allowance code", xed.getIssueText());
     }
 
     @Test
@@ -986,7 +986,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7202", xed.getElementId());
-        assertEquals("Missing method of handling code", xed.getMessage());
+        assertEquals("Missing method of handling code", xed.getIssueText());
     }
 
     @Test
@@ -1015,7 +1015,7 @@ public class DefaultDex894ValidatorTest {
 
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7202", xed.getElementId());
-        assertEquals("Missing method of handling code", xed.getMessage());
+        assertEquals("Missing method of handling code", xed.getIssueText());
 
         xed = errors.stream()
             .filter(errDetail -> "G7201".equals(errDetail.getElementId()))
@@ -1024,7 +1024,7 @@ public class DefaultDex894ValidatorTest {
 
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7201", xed.getElementId());
-        assertEquals("Missing allowance code", xed.getMessage());
+        assertEquals("Missing allowance code", xed.getIssueText());
     }
 
     @Test
@@ -1044,7 +1044,7 @@ public class DefaultDex894ValidatorTest {
         X12ErrorDetail xed = errors.stream().findFirst().get();
         assertEquals("G72", xed.getSegmentId());
         assertEquals("G7205", xed.getElementId());
-        assertEquals("Must have allowance rate, percent, or amount", xed.getMessage());
+        assertEquals("Must have allowance rate, percent, or amount", xed.getIssueText());
     }
 
     @Test

--- a/src/test/java/com/walmartlabs/x12/standard/StandardX12ParserNoRegisteredTransactionSetParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/StandardX12ParserNoRegisteredTransactionSetParserTest.java
@@ -107,7 +107,7 @@ public class StandardX12ParserNoRegisteredTransactionSetParserTest {
         String sourceData = X12DocumentTestData.readFile("src/test/resources/x12.wrong.GS.txt");
 
         exception.expect(X12ParserException.class);
-        exception.expectMessage("expected GS segment but found XX");
+        exception.expectMessage("expected one segment but found another");
 
         standardParser.parse(sourceData);
     }

--- a/src/test/java/com/walmartlabs/x12/standard/txset/asn856/Asn856ParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/txset/asn856/Asn856ParserTest.java
@@ -171,8 +171,8 @@ public class Asn856ParserTest {
         X12ErrorDetail loopError = loopErrors.get(0);
         assertEquals("HL", loopError.getSegmentId());
         assertNull(loopError.getElementId());
-        assertNull(loopError.getLineNumber());
-        assertEquals("HL segment with id (2) is missing parent (99)", loopError.getMessage());
+        assertEquals("HL segment is missing parent", loopError.getIssueText());
+        assertEquals("HL segment with id (2) is missing parent (99)", loopError.getInvalidValue());
 
         // BSN
         assertEquals("14", asnTx.getPurposeCode());

--- a/src/test/java/com/walmartlabs/x12/standard/txset/asn856/DefaultAsn856TransactionSetParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/txset/asn856/DefaultAsn856TransactionSetParserTest.java
@@ -111,7 +111,13 @@ public class DefaultAsn856TransactionSetParserTest {
             txParser.doParse(segments, x12Group);
             fail("expected parsing exception");
         } catch (X12ParserException e) {
-            assertEquals("expected BSN segment but found SE", e.getMessage());
+            assertEquals("expected one segment but found another", e.getMessage());
+            
+            
+            X12ErrorDetail errorDetail = ((X12ParserException) e).getErrorDetail();
+            assertNotNull(errorDetail);
+            assertEquals("expected one segment but found another", errorDetail.getIssueText());
+            assertEquals("expected BSN segment but found SE", errorDetail.getInvalidValue());
         }
     }
 
@@ -125,7 +131,12 @@ public class DefaultAsn856TransactionSetParserTest {
             txParser.doParse(segments, x12Group);
             fail("expected parsing exception");
         } catch (X12ParserException e) {
-            assertEquals("expected SE segment but found SN1", e.getMessage());
+            assertEquals("expected one segment but found another", e.getMessage());
+            
+            X12ErrorDetail errorDetail = ((X12ParserException) e).getErrorDetail();
+            assertNotNull(errorDetail);
+            assertEquals("expected one segment but found another", errorDetail.getIssueText());
+            assertEquals("expected SE segment but found SN1", errorDetail.getInvalidValue());
         }
     }
 
@@ -142,7 +153,7 @@ public class DefaultAsn856TransactionSetParserTest {
         List<X12ErrorDetail> loopErrors = asnTx.getLoopingErrors();
         assertNotNull(loopErrors);
         assertEquals(1, loopErrors.size());
-        assertEquals("missing shipment loop", loopErrors.get(0).getMessage());
+        assertEquals("missing shipment loop", loopErrors.get(0).getIssueText());
 
         // BSN
         assertEquals("05755986", asnTx.getShipmentIdentification());
@@ -160,7 +171,7 @@ public class DefaultAsn856TransactionSetParserTest {
         // looping check
         List<X12ErrorDetail> loopErrors = asnTx.getLoopingErrors();
         assertEquals(1, loopErrors.size());
-        assertEquals("first HL is not a shipment it was X", loopErrors.get(0).getMessage());
+        assertEquals("first HL is not a shipment it was X", loopErrors.get(0).getIssueText());
 
         // BSN
         assertEquals("05755986", asnTx.getShipmentIdentification());
@@ -178,7 +189,7 @@ public class DefaultAsn856TransactionSetParserTest {
         // looping check
         List<X12ErrorDetail> loopErrors = asnTx.getLoopingErrors();
         assertEquals(1, loopErrors.size());
-        assertEquals("expected Order HL but got X", loopErrors.get(0).getMessage());
+        assertEquals("expected Order HL but got X", loopErrors.get(0).getIssueText());
 
         // BSN
         assertEquals("05755986", asnTx.getShipmentIdentification());
@@ -196,7 +207,7 @@ public class DefaultAsn856TransactionSetParserTest {
         // looping check
         List<X12ErrorDetail> loopErrors = asnTx.getLoopingErrors();
         assertEquals(1, loopErrors.size());
-        assertEquals("expected one top level HL", loopErrors.get(0).getMessage());
+        assertEquals("expected one top level HL", loopErrors.get(0).getIssueText());
 
         // BSN
         assertEquals("05755986", asnTx.getShipmentIdentification());

--- a/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericParserTest.java
@@ -418,8 +418,12 @@ public class GenericParserTest {
         List<X12ErrorDetail> loopErrors = genericTx.getLoopingErrors();
         assertNotNull(loopErrors);
         assertEquals(2, loopErrors.size());
-        assertEquals("HL segment with id (1) already exists", loopErrors.get(0).getMessage());
-        assertEquals("HL segment with id (3) is missing parent (2)", loopErrors.get(1).getMessage());
+        // loop error 1
+        assertEquals("HL segment already exists", loopErrors.get(0).getIssueText());
+        assertEquals("HL segment with id (1) already exists", loopErrors.get(0).getInvalidValue());
+        // loop error 2
+        assertEquals("HL segment is missing parent", loopErrors.get(1).getIssueText());
+        assertEquals("HL segment with id (3) is missing parent (2)", loopErrors.get(1).getInvalidValue());
 
         // Shipment
         X12Loop shipmentLoop = topLoops.get(0);

--- a/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/standard/txset/generic/GenericTransactionSetParserTest.java
@@ -63,7 +63,12 @@ public class GenericTransactionSetParserTest {
             txParser.doParse(segments, x12Group);
             fail("expected parsing exception");
         } catch (X12ParserException e) {
-            assertEquals("expected Beginning segment but found SE", e.getMessage());
+            assertEquals("expected one segment but found another", e.getMessage());
+            
+            X12ErrorDetail errorDetail = ((X12ParserException) e).getErrorDetail();
+            assertNotNull(errorDetail);
+            assertEquals("expected one segment but found another", errorDetail.getIssueText());
+            assertEquals("expected Beginning segment but found SE", errorDetail.getInvalidValue());
         }
     }
 

--- a/src/test/java/com/walmartlabs/x12/util/loop/X12LoopUtilTest.java
+++ b/src/test/java/com/walmartlabs/x12/util/loop/X12LoopUtilTest.java
@@ -274,8 +274,8 @@ public class X12LoopUtilTest {
         X12ErrorDetail loopError = loopErrors.get(0);
         assertEquals("HL", loopError.getSegmentId());
         assertNull(loopError.getElementId());
-        assertNull(loopError.getLineNumber());
-        assertEquals("HL segment with id (4) is missing parent (3)", loopError.getMessage());
+        assertEquals("HL segment is missing parent", loopError.getIssueText());
+        assertEquals("HL segment with id (4) is missing parent (3)", loopError.getInvalidValue());
     }
 
     @Test
@@ -347,8 +347,8 @@ public class X12LoopUtilTest {
         X12ErrorDetail loopError = loopErrors.get(0);
         assertEquals("HL", loopError.getSegmentId());
         assertNull(loopError.getElementId());
-        assertNull(loopError.getLineNumber());
-        assertEquals("HL segment with id (2) already exists", loopError.getMessage());
+        assertEquals("HL segment already exists", loopError.getIssueText());
+        assertEquals("HL segment with id (2) already exists", loopError.getInvalidValue());
     }
 
     @Test
@@ -437,8 +437,8 @@ public class X12LoopUtilTest {
         X12ErrorDetail loopError = loopErrors.get(0);
         assertEquals("TOP", loopError.getSegmentId());
         assertNull(loopError.getElementId());
-        assertNull(loopError.getLineNumber());
-        assertEquals("expected HL segment but found TOP", loopError.getMessage());
+        assertEquals("expected one segment but found another", loopError.getIssueText());
+        assertEquals("expected HL segment but found TOP", loopError.getInvalidValue());
     }
 
 }

--- a/src/test/java/sample/parser/X12SampleTest.java
+++ b/src/test/java/sample/parser/X12SampleTest.java
@@ -68,7 +68,7 @@ public class X12SampleTest {
         assertNotNull(x12Error);
         assertEquals("TST", x12Error.getSegmentId());
         assertEquals("01", x12Error.getElementId());
-        assertEquals("missing functional id", x12Error.getMessage());
+        assertEquals("missing functional id", x12Error.getIssueText());
 
         assertEquals(null, ((SampleX12Document) x12).getFunctionalId());
     }
@@ -89,7 +89,7 @@ public class X12SampleTest {
             assertNotNull(x12Error);
             assertEquals("TST", x12Error.getSegmentId());
             assertEquals("00", x12Error.getElementId());
-            assertEquals("invalid functional group code", x12Error.getMessage());
+            assertEquals("invalid functional group code", x12Error.getIssueText());
         }
     }
 


### PR DESCRIPTION
Fix for #131 

- removes `lineNumber` from `X12ErrorDetail` (not being used)
- renames `message` on `X12ErrorDetail` to `issueText`
- adds `invalidValue` to `X12ErrorDetail`

