### PR TITLE
Add handling for REF03 and REF04

### DIFF
--- a/src/main/java/com/walmartlabs/x12/common/segment/REFReferenceInformation.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/REFReferenceInformation.java
@@ -18,7 +18,18 @@ package com.walmartlabs.x12.common.segment;
 
 /**
  *
- * Purpose: To specify pertinent dates and times
+ * Purpose: Reference Information
+ * 
+ * Contains 4 data elements, the 4th can hold multiple values and is 
+ * usually delimited by a ">" but which can be specified to be 
+ * a different character in the ISA segment
+ * 
+ * REF*PK*1234**BM>4321
+ * 
+ * This object will hold the entire REF04 value in the 
+ * attribute `additionalReferenceIdentification`
+ * expecting a separate process to manage parsing it
+ * into its parts
  *
  */
 public class REFReferenceInformation {
@@ -30,6 +41,12 @@ public class REFReferenceInformation {
 
     // REF02
     private String referenceIdentification;
+    
+    // REF03
+    private String description;
+
+    // REF04
+    private String additionalReferenceIdentification;
 
     public String getReferenceIdentificationQualifier() {
         return referenceIdentificationQualifier;
@@ -47,4 +64,20 @@ public class REFReferenceInformation {
         this.referenceIdentification = referenceIdentification;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getAdditionalReferenceIdentification() {
+        return additionalReferenceIdentification;
+    }
+
+    public void setAdditionalReferenceIdentification(String additionalReferenceIdentification) {
+        this.additionalReferenceIdentification = additionalReferenceIdentification;
+    }
+    
 }

--- a/src/main/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParser.java
+++ b/src/main/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParser.java
@@ -35,6 +35,8 @@ public final class REFReferenceInformationParser {
                 ref = new REFReferenceInformation();
                 ref.setReferenceIdentificationQualifier(segment.getElement(1));
                 ref.setReferenceIdentification(segment.getElement(2));
+                ref.setDescription(segment.getElement(3));
+                ref.setAdditionalReferenceIdentification(segment.getElement(4));
             }
         }
         return ref;

--- a/src/test/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParserTest.java
+++ b/src/test/java/com/walmartlabs/x12/common/segment/parser/REFReferenceInformationParserTest.java
@@ -42,10 +42,12 @@ public class REFReferenceInformationParserTest {
 
     @Test
     public void test_parse_segment() {
-        X12Segment segment = new X12Segment("REF*UCB*711170010491361");
+        X12Segment segment = new X12Segment("REF*UCB*711170010491361*TEST*BM>1234");
         REFReferenceInformation ref = REFReferenceInformationParser.parse(segment);
         assertNotNull(ref);
         assertEquals("UCB", ref.getReferenceIdentificationQualifier());
         assertEquals("711170010491361", ref.getReferenceIdentification());
+        assertEquals("TEST", ref.getDescription());
+        assertEquals("BM>1234", ref.getAdditionalReferenceIdentification());
     }
 }


### PR DESCRIPTION
The `REFReferenceInformation` implementation only had attributes to capture REF00, REF01 and REEF02 
This will add attributes for REF03 (description) and REF04 (additional reference information)