### PR TITLE
update version of jacoco-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,13 @@
   <build>
     <plugins>
       <!-- code coverage -->
+      <!-- some versions caused forking issues 
+      		with JDK versions > 8
+      -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.8</version>
         <executions>
           <execution>
             <id>jacoco-initialize</id>


### PR DESCRIPTION
Updating plugin to avoid -JVM fork error when building w/ JDK 17